### PR TITLE
Expand feature backlog with enterprise PoC and passive income items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,28 +27,30 @@ See `README.md` files in each folder for the specific remaining items.
 
 ### Tier 1 — Høj værdi, bygger på eksisterende infrastruktur
 
+- [ ] **Personal health API** — FastAPI på Mac Mini der eksponerer gold-laget som REST endpoint. Fundament for alt andet — widgets, Shortcuts, andre apps. Ingen ny infrastruktur.
 - [ ] **Ugentlig health digest** — automatisk Markdown-rapport hver mandag via GitHub Actions cron. Forrige uge vs ugen før på tværs af alle silver-tabeller. Ingen ny infrastruktur.
 - [ ] **Anomali-detektor** — flag usædvanlige målinger (meget høj puls, meget lav søvnscore) med simpel statistik (z-score eller percentil). Ren SQL/Python.
 - [ ] **Master data annoterings-app** — lokal Streamlit-app til manuel annotation af kontekst wearables ikke kan fange: sygdom, rejse, stress, ny træningsrutine. Gemmes i `gold.daily_annotations` og joines på alle gold-views.
-- [ ] **Databricks AI/BI dashboard** — gold-laget eksisterer, naturligt næste skridt. Viser trends, scores og anomalier. Ingen ekstra infrastruktur når Databricks er konfigureret.
 
 ### Tier 2 — Høj værdi, mere arbejde
 
+- [ ] **Lokal Streamlit-dashboard** — interaktivt health dashboard der kører på Mac Mini og læser direkte fra DuckDB eller health API. Flersidet layout: søvn / aktivitet / vitals / trends. Tilgængeligt fra telefon/iPad via lokalt netværk.
 - [ ] **Korrelationsmotor** — automatisk find sammenhænge på tværs af metrics. "Dage med søvnscore > 80 giver X% lavere hvilepuls næste dag." Ren SQL, ingen ML.
 - [ ] **Composite health score** — ét dagligt tal beregnet fra søvn + aktivitet + stress + readiness. Defineres som en gold-view med vægtede inputs.
-- [ ] **Withings / Garmin connector** — flere datakilder ind i samme medallion-arkitektur. Withings: vægt, blodtryk. Garmin: avancerede træningsmetrics.
+- [ ] **Withings / Garmin connector** — flere datakilder ind i samme medallion-arkitektur. Withings: vægt, blodtryk. Garmin: avancerede træningsmetrics. PoC for "plug in any source with one YAML".
 - [ ] **Familie-platform** — tilføj `user_id` dimension. Arkitekturen understøtter allerede source isolation — relativt lille refaktor at tracke flere brugeres data i samme platform.
 
-### Tier 3 — Længere sigt
+### Tier 3 — Enterprise PoC materiale
 
+- [ ] **Databricks AI/BI dashboard** — BI-værktøj direkte på gold-laget. Viser trends, scores og anomalier. Ingen ekstra infrastruktur når Databricks er konfigureret.
+- [ ] **Databricks Genie Space** — natural language interface til gold-data. "Hvad var min bedste uge i januar?" Killer demo til Pandora. Kræver kun gold-tabeller + Databricks konfiguration.
+- [ ] **Databricks PoC accelerator** — pak dette repo som en "30-minute Databricks PoC starter": medallion, CI/CD, dev/prd, metadata-driven. Brug internt hos Pandora som accelerator til nye dataprojekter.
 - [ ] **Forudsigelsesmodel** — baseret på gårsdagens søvn + aktivitet, forudsig dagens readiness. Simpel lineær regression. Kræver minimum 6 måneders historisk data.
-- [ ] **Personal health API** — FastAPI på Mac Mini der eksponerer gold-laget som REST endpoint. Gør data tilgængeligt for andre apps og devices.
-- [ ] **Lokal Streamlit-visualisering** — interaktivt health dashboard der kører på Mac Mini og læser direkte fra DuckDB. Flersidet layout: søvn / aktivitet / vitals / trends. Tilgængeligt fra telefon/iPad via lokalt netværk.
-- [ ] **Databricks AI/BI dashboard** — BI-værktøj direkte på gold-laget uden ekstra infrastruktur. AI-assistent der svarer på spørgsmål om dine data på naturligt sprog. Prioritér når Databricks er konfigureret.
 
 ### Tier 4 — Passiv indkomst
 
-- [ ] **Health data platform template** — sælg hele arkitekturen (medallion + connectors + dashboard) som Databricks-template til data engineers der vil tracke eget helbred. Udgangspunkt: dette repo poleret og generaliseret.
+- [ ] **Health data platform template** — sælg hele arkitekturen (medallion + connectors + dashboard) som Databricks-template til data engineers der vil tracke eget helbred. Udgangspunkt: dette repo poleret og generaliseret. Pris: $149-299.
+- [ ] **Personal health API som SaaS** — hosted version af health API med Oura/Apple Health integration. Månedlig subscription for andre der vil have det samme setup uden selv at bygge det.
 - [ ] **Anonymiseret benchmark** — "Din søvnscore er i top 30% for mænd 35-45." Kræver opt-in data fra andre brugere og privacy-arkitektur.
 
 ## Databricks Framework — Enterprise Scale-Up


### PR DESCRIPTION
## Summary

- Omstrukturerede Feature tiers med klarere prioritering
- Fjernede duplikat AI/BI dashboard (stod i både Tier 1 og Tier 3)
- Tilføjet nye punkter:
  - **Tier 1**: Personal health API som fundament for alt andet
  - **Tier 2**: Lokal Streamlit-dashboard
  - **Tier 3**: Databricks Genie Space + PoC accelerator til Pandora
  - **Tier 4**: Personal health API som SaaS med månedlig subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)