### PR TITLE
Add 3 agent shortcut slash commands

### DIFF
--- a/.claude/commands/dq-check.md
+++ b/.claude/commands/dq-check.md
@@ -1,0 +1,11 @@
+Run the data-quality-checker agent on all silver tables in the local DuckDB.
+
+Use the data-quality-checker agent to:
+1. Connect to the DuckDB file for the current HEALTH_ENV (default: dev)
+2. Run freshness, row count, null rate, and anomaly checks on all silver tables
+3. Output results in the standard format:
+   FRESHNESS:  ✓/✗ per table
+   ROW COUNTS: ✓/✗ per table
+   NULLS:      ✓/✗ key columns
+   ANOMALIES:  [ANOMALY] entries if any
+4. Flag any table where hours_stale > 25 or row count = 0

--- a/.claude/commands/poc-demo.md
+++ b/.claude/commands/poc-demo.md
@@ -1,0 +1,9 @@
+Generate a Pandora PoC demo document using the poc-presenter agent.
+
+Use the poc-presenter agent to:
+1. Read docs/architecture.md for current architecture state
+2. Generate a demo script following the 6-step structure (problem → architecture → YAML → CI/CD → dev/prd → scale-up)
+3. Include slide talking points (one-liners)
+4. Write the output to docs/poc_demo_$CURRENT_DATE.md
+
+Today's date: use current date in YYYY-MM-DD format for the filename.

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,7 @@
+Run the security-reviewer agent on all changes in the current branch.
+
+Use the security-reviewer agent to check:
+1. Run `git diff main...HEAD --name-only` to get changed files
+2. Read each changed file and apply all checks from the security-reviewer agent
+3. Output findings using [CRITICAL] / [WARN] / [NOTE] format
+4. End with SECURE or REVIEW NEEDED verdict


### PR DESCRIPTION
## Summary
- `/security-review` — kører security-reviewer agent på alle ændringer i branchen
- `/dq-check` — kører data-quality-checker på alle silver tables i DuckDB
- `/poc-demo` — genererer Pandora PoC demo-dokument via poc-presenter agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)