### PR TITLE
Port dim_date and dim_time to silver layer

### DIFF
--- a/health_unified_platform/health_platform/transformation_logic/databricks/silver/dim_date.py
+++ b/health_unified_platform/health_platform/transformation_logic/databricks/silver/dim_date.py
@@ -1,0 +1,93 @@
+# Databricks notebook source
+from pyspark.sql.functions import (
+    year, quarter, month, weekofyear, dayofweek, dayofyear, dayofmonth,
+    date_format, concat, lpad, when, lower
+)
+from datetime import datetime, timedelta
+
+start_date = datetime(2017, 1, 1)
+end_date = datetime.today() + timedelta(days=2*365)
+
+dates = [start_date + timedelta(days=x) for x in range((end_date - start_date).days + 1)]
+df = spark.createDataFrame([(d,) for d in dates], ["date"])
+
+df = (
+    df.withColumn("sk_date", year("date") * 10000 + month("date") * 100 + dayofmonth("date"))
+      .withColumn("year", year("date"))
+      .withColumn("quarter", quarter("date"))
+      .withColumn("month", month("date"))
+      .withColumn("week", weekofyear("date"))
+      .withColumn("day_of_week", dayofweek("date"))
+      .withColumn("day_of_year", dayofyear("date"))
+      .withColumn("day_of_month", dayofmonth("date"))
+      .withColumn("month_name", lower(date_format("date", "MMMM")))
+      .withColumn("day_name", lower(date_format("date", "EEEE")))
+      .withColumn("is_leap_year", when(
+          (year("date") % 4 == 0) & ((year("date") % 100 != 0) | (year("date") % 400 == 0)), 1
+      ).otherwise(0))
+      .withColumn("year_month", concat(year("date"), lpad(month("date"), 2, "0")))
+      .withColumn("is_weekend", when(
+          (dayofweek("date") == 1) | (dayofweek("date") == 7), 1
+      ).otherwise(0))
+)
+
+df.write.format("delta").mode("overwrite").saveAsTable("health_dw.silver.dim_date_staging")
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC CREATE TABLE IF NOT EXISTS health_dw.silver.dim_date
+# MAGIC USING DELTA
+# MAGIC AS SELECT * FROM health_dw.silver.dim_date_staging WHERE 1=0;
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC MERGE INTO health_dw.silver.dim_date AS target
+# MAGIC USING health_dw.silver.dim_date_staging AS source
+# MAGIC ON target.sk_date = source.sk_date
+# MAGIC
+# MAGIC WHEN MATCHED AND (
+# MAGIC     target.year <> source.year OR
+# MAGIC     target.quarter <> source.quarter OR
+# MAGIC     target.month <> source.month OR
+# MAGIC     target.week <> source.week OR
+# MAGIC     target.day_of_week <> source.day_of_week OR
+# MAGIC     target.day_of_year <> source.day_of_year OR
+# MAGIC     target.day_of_month <> source.day_of_month OR
+# MAGIC     target.month_name <> source.month_name OR
+# MAGIC     target.day_name <> source.day_name OR
+# MAGIC     target.is_leap_year <> source.is_leap_year OR
+# MAGIC     target.year_month <> source.year_month OR
+# MAGIC     target.is_weekend <> source.is_weekend
+# MAGIC )
+# MAGIC THEN UPDATE SET
+# MAGIC     target.date = source.date,
+# MAGIC     target.year = source.year,
+# MAGIC     target.quarter = source.quarter,
+# MAGIC     target.month = source.month,
+# MAGIC     target.week = source.week,
+# MAGIC     target.day_of_week = source.day_of_week,
+# MAGIC     target.day_of_year = source.day_of_year,
+# MAGIC     target.day_of_month = source.day_of_month,
+# MAGIC     target.month_name = source.month_name,
+# MAGIC     target.day_name = source.day_name,
+# MAGIC     target.is_leap_year = source.is_leap_year,
+# MAGIC     target.year_month = source.year_month,
+# MAGIC     target.is_weekend = source.is_weekend
+# MAGIC
+# MAGIC WHEN NOT MATCHED THEN
+# MAGIC   INSERT (
+# MAGIC     date, sk_date, year, quarter, month, week, day_of_week, day_of_year, day_of_month,
+# MAGIC     month_name, day_name, is_leap_year, year_month, is_weekend
+# MAGIC   )
+# MAGIC   VALUES (
+# MAGIC     source.date, source.sk_date, source.year, source.quarter, source.month, source.week,
+# MAGIC     source.day_of_week, source.day_of_year, source.day_of_month, source.month_name,
+# MAGIC     source.day_name, source.is_leap_year, source.year_month, source.is_weekend
+# MAGIC   );
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC DROP TABLE IF EXISTS health_dw.silver.dim_date_staging;

--- a/health_unified_platform/health_platform/transformation_logic/databricks/silver/dim_time.py
+++ b/health_unified_platform/health_platform/transformation_logic/databricks/silver/dim_time.py
@@ -1,0 +1,163 @@
+# Databricks notebook source
+from pyspark.sql import functions as F
+
+df = (
+    spark.range(0, 24)
+    .withColumnRenamed("id", "hour")
+    .crossJoin(
+        spark.range(0, 60).withColumnRenamed("id", "minute")
+    )
+    .withColumn(
+        "sk_time",
+        F.concat(
+            F.lpad(F.col("hour"), 2, "0"),
+            F.lpad(F.col("minute"), 2, "0")
+        )
+    )
+    .withColumn(
+        "time_code",
+        F.concat(
+            F.lpad(F.col("hour"), 2, "0"),
+            F.lit(":"),
+            F.lpad(F.col("minute"), 2, "0")
+        )
+    )
+    .withColumn("hour_12_code", F.lpad(F.col("hour") % 12, 2, "0"))
+    .withColumn("hour_12_key", F.col("hour") % 12)
+    .withColumn("minute_code", F.lpad(F.col("minute"), 2, "0"))
+    .withColumn("minute_key", F.col("minute"))
+    .withColumn("ampm_code", F.when(F.col("hour") < 12, "AM").otherwise("PM"))
+    .withColumn("hour_24_code", F.lpad(F.col("hour"), 2, "0"))
+    .withColumn("hour_24_key", F.col("hour"))
+    .withColumn(
+        "minute_15_code",
+        F.when(
+            F.col("minute") < 15,
+            F.concat(
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":00-"),
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":15")
+            )
+        )
+        .when(
+            (F.col("minute") >= 15) & (F.col("minute") < 30),
+            F.concat(
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":15-"),
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":30")
+            )
+        )
+        .when(
+            (F.col("minute") >= 30) & (F.col("minute") < 45),
+            F.concat(
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":30-"),
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":45")
+            )
+        )
+        .otherwise(
+            F.concat(
+                F.lpad(F.col("hour"), 2, "0"),
+                F.lit(":45-"),
+                F.lpad(((F.col("hour") + 1) % 24), 2, "0"),
+                F.lit(":00")
+            )
+        )
+    )
+    .withColumn(
+        "minute_15_key",
+        F.when(F.col("minute") < 15, F.col("hour") * 100)
+        .when((F.col("minute") >= 15) & (F.col("minute") < 30), F.col("hour") * 100 + 15)
+        .when((F.col("minute") >= 30) & (F.col("minute") < 45), F.col("hour") * 100 + 30)
+        .otherwise(F.col("hour") * 100 + 45)
+    )
+    .select(
+        "sk_time",
+        "time_code",
+        "hour_12_code",
+        "hour_12_key",
+        "minute_code",
+        "minute_key",
+        "ampm_code",
+        "hour_24_code",
+        "hour_24_key",
+        "minute_15_code",
+        "minute_15_key"
+    )
+)
+
+df.write.format("delta").mode("overwrite").saveAsTable("health_dw.silver.dim_time_staging")
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC CREATE TABLE IF NOT EXISTS health_dw.silver.dim_time
+# MAGIC USING DELTA
+# MAGIC AS SELECT * FROM health_dw.silver.dim_time_staging WHERE 1=0;
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC MERGE INTO health_dw.silver.dim_time AS target
+# MAGIC USING health_dw.silver.dim_time_staging AS source
+# MAGIC ON target.sk_time = source.sk_time
+# MAGIC
+# MAGIC WHEN MATCHED AND (
+# MAGIC     target.time_code         <> source.time_code OR
+# MAGIC     target.hour_12_code      <> source.hour_12_code OR
+# MAGIC     target.hour_12_key       <> source.hour_12_key OR
+# MAGIC     target.minute_code       <> source.minute_code OR
+# MAGIC     target.minute_key        <> source.minute_key OR
+# MAGIC     target.ampm_code         <> source.ampm_code OR
+# MAGIC     target.hour_24_code      <> source.hour_24_code OR
+# MAGIC     target.hour_24_key       <> source.hour_24_key OR
+# MAGIC     target.minute_15_code    <> source.minute_15_code OR
+# MAGIC     target.minute_15_key     <> source.minute_15_key
+# MAGIC )
+# MAGIC THEN UPDATE SET
+# MAGIC     target.time_code         = source.time_code,
+# MAGIC     target.hour_12_code      = source.hour_12_code,
+# MAGIC     target.hour_12_key       = source.hour_12_key,
+# MAGIC     target.minute_code       = source.minute_code,
+# MAGIC     target.minute_key        = source.minute_key,
+# MAGIC     target.ampm_code         = source.ampm_code,
+# MAGIC     target.hour_24_code      = source.hour_24_code,
+# MAGIC     target.hour_24_key       = source.hour_24_key,
+# MAGIC     target.minute_15_code    = source.minute_15_code,
+# MAGIC     target.minute_15_key     = source.minute_15_key
+# MAGIC
+# MAGIC WHEN NOT MATCHED THEN
+# MAGIC   INSERT (
+# MAGIC     sk_time,
+# MAGIC     time_code,
+# MAGIC     hour_12_code,
+# MAGIC     hour_12_key,
+# MAGIC     minute_code,
+# MAGIC     minute_key,
+# MAGIC     ampm_code,
+# MAGIC     hour_24_code,
+# MAGIC     hour_24_key,
+# MAGIC     minute_15_code,
+# MAGIC     minute_15_key
+# MAGIC   )
+# MAGIC   VALUES (
+# MAGIC     source.sk_time,
+# MAGIC     source.time_code,
+# MAGIC     source.hour_12_code,
+# MAGIC     source.hour_12_key,
+# MAGIC     source.minute_code,
+# MAGIC     source.minute_key,
+# MAGIC     source.ampm_code,
+# MAGIC     source.hour_24_code,
+# MAGIC     source.hour_24_key,
+# MAGIC     source.minute_15_code,
+# MAGIC     source.minute_15_key
+# MAGIC   );
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC DROP TABLE IF EXISTS health_dw.silver.dim_time_staging;


### PR DESCRIPTION
## Summary
- Ports `date.py` and `time.py` from `archive/legacy_databricks_pipeline/silver/notebook/` to `transformation_logic/databricks/silver/`
- Tables renamed from `date`/`time` → `dim_date`/`dim_time` (consistent `dim_` prefix)
- Added `CREATE TABLE IF NOT EXISTS` guard before MERGE (missing in original)
- Logic and all column names preserved exactly

## Notes
Generated dimensions (not bronze-sourced) — standalone notebooks outside the `silver_runner.py` YAML-driven flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)