### PR TITLE
Add dbt models and merge scripts for 4 missing silver tables

### DIFF
--- a/claude_code_productivity.json
+++ b/claude_code_productivity.json
@@ -3,7 +3,7 @@
     "project": "HealthReporting",
     "owner": "Claus Eduard Petraeus",
     "claude_code_start_date": "2026-02-16",
-    "last_updated": "2026-02-26",
+    "last_updated": "2026-02-27",
     "methodology": "See claude_code_productivity.md"
   },
   "baseline": {
@@ -21,14 +21,14 @@
     "period": {
       "from": "2026-02-16"
     },
-    "total_commits": 67,
+    "total_commits": 71,
     "active_weeks": 2,
-    "avg_commits_per_active_week": 33.5,
-    "avg_files_per_commit": 13.6
+    "avg_commits_per_active_week": 35.5,
+    "avg_files_per_commit": 13.7
   },
   "factors": {
-    "velocity_factor": 8.17,
-    "files_per_commit_factor": 1.36,
+    "velocity_factor": 8.66,
+    "files_per_commit_factor": 1.37,
     "description": "velocity_factor = commits/active_week (Claude) / commits/active_week (baseline). files_per_commit_factor = avg_files (Claude) / avg_files (baseline)."
   },
   "entries": [
@@ -1037,6 +1037,66 @@
       "code_density": null,
       "time_since_prev_commit_minutes": 0,
       "streak_days": 1
+    },
+    {
+      "commit_sha": "2a2e8f5",
+      "date": "2026-02-27",
+      "message": "Port legacy silver SQL to Databricks notebooks, delete archive copies",
+      "task_type": "archive",
+      "commit_hour": 3,
+      "files_changed": 34,
+      "lines_added": 1220,
+      "lines_removed": 1143,
+      "files_factor": 3.4,
+      "refactor_ratio": 0.484,
+      "code_density": 35.9,
+      "time_since_prev_commit_minutes": 287,
+      "streak_days": 2
+    },
+    {
+      "commit_sha": "cde9c87",
+      "date": "2026-02-27",
+      "message": "Merge pull request #18 from EduardPetraeus/feature/port-legacy-silver-sql",
+      "task_type": "archive",
+      "commit_hour": 3,
+      "files_changed": 0,
+      "lines_added": 0,
+      "lines_removed": 0,
+      "files_factor": 0,
+      "refactor_ratio": null,
+      "code_density": null,
+      "time_since_prev_commit_minutes": 1,
+      "streak_days": 2
+    },
+    {
+      "commit_sha": "f5adf4d",
+      "date": "2026-02-27",
+      "message": "Convert silver/gold Python notebooks to pure SQL files",
+      "task_type": "other",
+      "commit_hour": 3,
+      "files_changed": 22,
+      "lines_added": 912,
+      "lines_removed": 902,
+      "files_factor": 2.2,
+      "refactor_ratio": 0.497,
+      "code_density": 41.5,
+      "time_since_prev_commit_minutes": 6,
+      "streak_days": 2
+    },
+    {
+      "commit_sha": "0d49cdd",
+      "date": "2026-02-27",
+      "message": "Update README and TODO to reflect SQL migration completion",
+      "task_type": "docs",
+      "commit_hour": 3,
+      "files_changed": 4,
+      "lines_added": 74,
+      "lines_removed": 21,
+      "files_factor": 0.4,
+      "refactor_ratio": 0.221,
+      "code_density": 18.5,
+      "time_since_prev_commit_minutes": 2,
+      "streak_days": 2
     }
   ]
 }

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_blood_oxygen.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_blood_oxygen.sql
@@ -1,0 +1,52 @@
+-- merge_oura_blood_oxygen.sql
+-- Per-source merge: Oura API -> silver.blood_oxygen
+-- Business key: timestamp + source (per-minute continuous SpO2 readings)
+--
+-- Usage: python run_merge.py silver/merge_oura_blood_oxygen.sql
+
+CREATE OR REPLACE TABLE silver.blood_oxygen__staging AS
+WITH deduped AS (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY timestamp, source ORDER BY _ingested_at DESC) AS rn
+    FROM bronze.stg_oura_blood_oxygen
+    WHERE timestamp IS NOT NULL
+)
+SELECT
+    (year(timestamp::TIMESTAMP) * 10000 + month(timestamp::TIMESTAMP) * 100 + day(timestamp::TIMESTAMP))::INTEGER AS sk_date,
+    lpad(hour(timestamp::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(timestamp::TIMESTAMP)::VARCHAR, 2, '0')       AS sk_time,
+    timestamp::TIMESTAMP              AS timestamp,
+    spo2::DOUBLE                      AS spo2,
+    source                            AS source,
+    md5(
+        coalesce(timestamp, '') || '||' || coalesce(source, '')
+    )                                 AS business_key_hash,
+    md5(
+        coalesce(timestamp, '')               || '||' ||
+        coalesce(cast(spo2 AS VARCHAR), '')   || '||' ||
+        coalesce(source, '')
+    )                                 AS row_hash,
+    current_timestamp                 AS load_datetime
+FROM deduped WHERE rn = 1;
+
+MERGE INTO silver.blood_oxygen AS target
+USING silver.blood_oxygen__staging AS src
+ON target.business_key_hash = src.business_key_hash
+
+WHEN MATCHED AND target.row_hash <> src.row_hash THEN UPDATE SET
+    sk_date         = src.sk_date,
+    sk_time         = src.sk_time,
+    timestamp       = src.timestamp,
+    spo2            = src.spo2,
+    source          = src.source,
+    row_hash        = src.row_hash,
+    update_datetime = current_timestamp
+
+WHEN NOT MATCHED THEN INSERT (
+    sk_date, sk_time, timestamp, spo2, source,
+    business_key_hash, row_hash, load_datetime, update_datetime
+) VALUES (
+    src.sk_date, src.sk_time, src.timestamp, src.spo2, src.source,
+    src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+);
+
+DROP TABLE IF EXISTS silver.blood_oxygen__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_blood_pressure.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_blood_pressure.sql
@@ -1,0 +1,57 @@
+-- merge_withings_blood_pressure.sql
+-- Per-source merge: Withings -> silver.blood_pressure
+-- Business key: datetime + systolic + diastolic (one reading per timestamp)
+--
+-- Usage: python run_merge.py silver/merge_withings_blood_pressure.sql
+
+CREATE OR REPLACE TABLE silver.blood_pressure__staging AS
+WITH deduped AS (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY datetime ORDER BY _ingested_at DESC) AS rn
+    FROM bronze.stg_withings_blood_pressure
+    WHERE datetime IS NOT NULL
+)
+SELECT
+    (year(datetime::TIMESTAMP) * 10000 + month(datetime::TIMESTAMP) * 100 + day(datetime::TIMESTAMP))::INTEGER AS sk_date,
+    lpad(hour(datetime::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(datetime::TIMESTAMP)::VARCHAR, 2, '0')      AS sk_time,
+    datetime::TIMESTAMP               AS datetime,
+    systolic::INTEGER                 AS systolic,
+    diastolic::INTEGER                AS diastolic,
+    pulse::INTEGER                    AS pulse,
+    md5(
+        coalesce(datetime, '')                             || '||' ||
+        coalesce(cast(systolic AS VARCHAR), '')            || '||' ||
+        coalesce(cast(diastolic AS VARCHAR), '')
+    )                                 AS business_key_hash,
+    md5(
+        coalesce(datetime, '')                             || '||' ||
+        coalesce(cast(systolic AS VARCHAR), '')            || '||' ||
+        coalesce(cast(diastolic AS VARCHAR), '')           || '||' ||
+        coalesce(cast(pulse AS VARCHAR), '')
+    )                                 AS row_hash,
+    current_timestamp                 AS load_datetime
+FROM deduped WHERE rn = 1;
+
+MERGE INTO silver.blood_pressure AS target
+USING silver.blood_pressure__staging AS src
+ON target.business_key_hash = src.business_key_hash
+
+WHEN MATCHED AND target.row_hash <> src.row_hash THEN UPDATE SET
+    sk_date         = src.sk_date,
+    sk_time         = src.sk_time,
+    datetime        = src.datetime,
+    systolic        = src.systolic,
+    diastolic       = src.diastolic,
+    pulse           = src.pulse,
+    row_hash        = src.row_hash,
+    update_datetime = current_timestamp
+
+WHEN NOT MATCHED THEN INSERT (
+    sk_date, sk_time, datetime, systolic, diastolic, pulse,
+    business_key_hash, row_hash, load_datetime, update_datetime
+) VALUES (
+    src.sk_date, src.sk_time, src.datetime, src.systolic, src.diastolic, src.pulse,
+    src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+);
+
+DROP TABLE IF EXISTS silver.blood_pressure__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_weight.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_weight.sql
@@ -1,0 +1,66 @@
+-- merge_withings_weight.sql
+-- Per-source merge: Withings -> silver.weight
+-- Business key: datetime + weight_kg + all mass fields (composite uniqueness)
+--
+-- Usage: python run_merge.py silver/merge_withings_weight.sql
+
+CREATE OR REPLACE TABLE silver.weight__staging AS
+WITH deduped AS (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY datetime, weight_kg ORDER BY _ingested_at DESC) AS rn
+    FROM bronze.stg_withings_weight
+    WHERE datetime IS NOT NULL
+)
+SELECT
+    (year(datetime::TIMESTAMP) * 10000 + month(datetime::TIMESTAMP) * 100 + day(datetime::TIMESTAMP))::INTEGER AS sk_date,
+    lpad(hour(datetime::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(datetime::TIMESTAMP)::VARCHAR, 2, '0')      AS sk_time,
+    datetime::TIMESTAMP               AS datetime,
+    weight_kg::DOUBLE                 AS weight_kg,
+    fat_mass_kg::DOUBLE               AS fat_mass_kg,
+    bone_mass_kg::DOUBLE              AS bone_mass_kg,
+    muscle_mass_kg::DOUBLE            AS muscle_mass_kg,
+    hydration_kg::DOUBLE              AS hydration_kg,
+    md5(
+        coalesce(datetime, '')                                  || '||' ||
+        coalesce(cast(weight_kg AS VARCHAR), '')                || '||' ||
+        coalesce(cast(fat_mass_kg AS VARCHAR), '')              || '||' ||
+        coalesce(cast(bone_mass_kg AS VARCHAR), '')             || '||' ||
+        coalesce(cast(muscle_mass_kg AS VARCHAR), '')           || '||' ||
+        coalesce(cast(hydration_kg AS VARCHAR), '')
+    )                                 AS business_key_hash,
+    md5(
+        coalesce(datetime, '')                                  || '||' ||
+        coalesce(cast(weight_kg AS VARCHAR), '')                || '||' ||
+        coalesce(cast(fat_mass_kg AS VARCHAR), '')              || '||' ||
+        coalesce(cast(bone_mass_kg AS VARCHAR), '')             || '||' ||
+        coalesce(cast(muscle_mass_kg AS VARCHAR), '')           || '||' ||
+        coalesce(cast(hydration_kg AS VARCHAR), '')
+    )                                 AS row_hash,
+    current_timestamp                 AS load_datetime
+FROM deduped WHERE rn = 1;
+
+MERGE INTO silver.weight AS target
+USING silver.weight__staging AS src
+ON target.business_key_hash = src.business_key_hash
+
+WHEN MATCHED AND target.row_hash <> src.row_hash THEN UPDATE SET
+    sk_date         = src.sk_date,
+    sk_time         = src.sk_time,
+    datetime        = src.datetime,
+    weight_kg       = src.weight_kg,
+    fat_mass_kg     = src.fat_mass_kg,
+    bone_mass_kg    = src.bone_mass_kg,
+    muscle_mass_kg  = src.muscle_mass_kg,
+    hydration_kg    = src.hydration_kg,
+    row_hash        = src.row_hash,
+    update_datetime = current_timestamp
+
+WHEN NOT MATCHED THEN INSERT (
+    sk_date, sk_time, datetime, weight_kg, fat_mass_kg, bone_mass_kg,
+    muscle_mass_kg, hydration_kg, business_key_hash, row_hash, load_datetime, update_datetime
+) VALUES (
+    src.sk_date, src.sk_time, src.datetime, src.weight_kg, src.fat_mass_kg, src.bone_mass_kg,
+    src.muscle_mass_kg, src.hydration_kg, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+);
+
+DROP TABLE IF EXISTS silver.weight__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/_sources.yml
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/_sources.yml
@@ -6,3 +6,6 @@ sources:
     tables:
       - name: stg_apple_health_heart_rate
       - name: stg_apple_health_step_count
+      - name: stg_oura_blood_oxygen
+      - name: stg_withings_blood_pressure
+      - name: stg_withings_weight

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_oxygen.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_oxygen.sql
@@ -1,0 +1,19 @@
+{{
+   config(materialized='table')
+}}
+
+-- Schema-only definition for silver.blood_oxygen.
+-- Run once with: dbt run --select blood_oxygen
+-- Data is loaded by: dbt/merge/silver/merge_oura_blood_oxygen.sql
+
+select
+    null::integer    as sk_date,
+    null::varchar    as sk_time,
+    null::timestamp  as timestamp,
+    null::double     as spo2,
+    null::varchar    as source,
+    null::varchar    as business_key_hash,
+    null::varchar    as row_hash,
+    null::timestamp  as load_datetime,
+    null::timestamp  as update_datetime
+where false

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_pressure.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_pressure.sql
@@ -1,0 +1,20 @@
+{{
+   config(materialized='table')
+}}
+
+-- Schema-only definition for silver.blood_pressure.
+-- Run once with: dbt run --select blood_pressure
+-- Data is loaded by: dbt/merge/silver/merge_withings_blood_pressure.sql
+
+select
+    null::integer    as sk_date,
+    null::varchar    as sk_time,
+    null::timestamp  as datetime,
+    null::integer    as systolic,
+    null::integer    as diastolic,
+    null::integer    as pulse,
+    null::varchar    as business_key_hash,
+    null::varchar    as row_hash,
+    null::timestamp  as load_datetime,
+    null::timestamp  as update_datetime
+where false

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_annotations.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_annotations.sql
@@ -1,0 +1,15 @@
+{{
+   config(materialized='table')
+}}
+
+-- Schema-only definition for silver.daily_annotations.
+-- Run once with: dbt run --select daily_annotations
+-- No merge script -- rows inserted directly as needed (manually curated, insert-only).
+
+select
+    null::integer    as sk_date,
+    null::varchar    as annotation_type,
+    null::varchar    as annotation,
+    null::varchar    as created_by,
+    null::boolean    as is_valid
+where false

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/weight.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/weight.sql
@@ -1,0 +1,22 @@
+{{
+   config(materialized='table')
+}}
+
+-- Schema-only definition for silver.weight.
+-- Run once with: dbt run --select weight
+-- Data is loaded by: dbt/merge/silver/merge_withings_weight.sql
+
+select
+    null::integer    as sk_date,
+    null::varchar    as sk_time,
+    null::timestamp  as datetime,
+    null::double     as weight_kg,
+    null::double     as fat_mass_kg,
+    null::double     as bone_mass_kg,
+    null::double     as muscle_mass_kg,
+    null::double     as hydration_kg,
+    null::varchar    as business_key_hash,
+    null::varchar    as row_hash,
+    null::timestamp  as load_datetime,
+    null::timestamp  as update_datetime
+where false


### PR DESCRIPTION
## Summary
- Add schema-only dbt models: `blood_oxygen`, `blood_pressure`, `daily_annotations`, `weight`
- Add DuckDB merge scripts for source-backed tables: `merge_oura_blood_oxygen.sql`, `merge_withings_blood_pressure.sql`, `merge_withings_weight.sql`
- Update `_sources.yml` with 3 new bronze table references
- Completes silver layer coverage: all 9 silver tables now have dbt models

## Test plan
- [x] `dbt run --select blood_oxygen blood_pressure daily_annotations weight` — PASS=4, WARN=0, ERROR=0
- [ ] Merge scripts validated via `EXPLAIN` once bronze tables are populated
- [ ] End-to-end merge runnable after Withings/Oura connectors deliver data

🤖 Generated with [Claude Code](https://claude.com/claude-code)