### PR TITLE
Fix job clusters: switch to serverless compute

### DIFF
--- a/health_unified_platform/health_environment/orchestration/bronze_job.yml
+++ b/health_unified_platform/health_environment/orchestration/bronze_job.yml
@@ -16,23 +16,11 @@ resources:
         timezone_id: UTC
         pause_status: UNPAUSED
 
-      job_clusters:
-        - job_cluster_key: bronze_cluster
-          new_cluster:
-            spark_version: 15.4.x-scala2.12
-            node_type_id: ${var.cluster_node_type}
-            num_workers: 2
-            spark_conf:
-              spark.databricks.delta.preview.enabled: "true"
-            spark_env_vars:
-              HEALTH_ENV: ${var.env}
-
       tasks:
         # ------------------------------------------------------------------
         # apple_health — heart rate
         # ------------------------------------------------------------------
         - task_key: bronze_apple_health_heart_rate
-          job_cluster_key: bronze_cluster
           notebook_task:
             notebook_path: ../../health_platform/transformation_logic/databricks/bronze/bronze_autoloader.py
             base_parameters:
@@ -43,7 +31,6 @@ resources:
         # oura — heart rate
         # ------------------------------------------------------------------
         - task_key: bronze_oura_heart_rate
-          job_cluster_key: bronze_cluster
           notebook_task:
             notebook_path: ../../health_platform/transformation_logic/databricks/bronze/bronze_autoloader.py
             base_parameters:

--- a/health_unified_platform/health_environment/orchestration/gold_job.yml
+++ b/health_unified_platform/health_environment/orchestration/gold_job.yml
@@ -13,18 +13,8 @@ resources:
         timezone_id: UTC
         pause_status: UNPAUSED
 
-      job_clusters:
-        - job_cluster_key: gold_cluster
-          new_cluster:
-            spark_version: 15.4.x-scala2.12
-            node_type_id: ${var.cluster_node_type}
-            num_workers: 2
-            spark_env_vars:
-              HEALTH_ENV: ${var.env}
-
       tasks:
         - task_key: gold_all_entities
-          job_cluster_key: gold_cluster
           notebook_task:
             notebook_path: ../../health_platform/transformation_logic/databricks/gold/gold_runner.py
             base_parameters:

--- a/health_unified_platform/health_environment/orchestration/silver_job.yml
+++ b/health_unified_platform/health_environment/orchestration/silver_job.yml
@@ -16,24 +16,12 @@ resources:
         timezone_id: UTC
         pause_status: UNPAUSED
 
-      job_clusters:
-        - job_cluster_key: silver_cluster
-          new_cluster:
-            spark_version: 15.4.x-scala2.12
-            node_type_id: ${var.cluster_node_type}
-            num_workers: 2
-            spark_conf:
-              spark.databricks.delta.preview.enabled: "true"
-            spark_env_vars:
-              HEALTH_ENV: ${var.env}
-
       tasks:
         # ------------------------------------------------------------------
         # Run all silver sources (leave source_name empty to process all)
         # Split into separate tasks if you need per-source control.
         # ------------------------------------------------------------------
         - task_key: silver_all_sources
-          job_cluster_key: silver_cluster
           notebook_task:
             notebook_path: ../../health_platform/transformation_logic/databricks/silver/silver_runner.py
             base_parameters:


### PR DESCRIPTION
## Summary

- Remove `job_clusters` / `new_cluster` config from all 3 jobs (bronze, silver, gold)
- Workspace only supports serverless compute — classic job clusters were rejected at deploy time
- `HEALTH_ENV` env var removed from job config (runners don't use it)
- Both `bundle validate --target dev` and `--target prd` pass clean

## Test plan

- [x] `databricks bundle validate --target dev` → `Validation OK!`
- [x] `databricks bundle validate --target prd` → `Validation OK!` (1 expected warning: Shared/ writable)
- [ ] GitHub Actions deploy to prd on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)