### PR TITLE
Security review: mandatory review rule and gitignore gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ logs/
 # Environment & secrets
 .env
 *.env
+*.token
+
+# Databricks local state
+.databricks-resources.json
 
 # Mac / IDE
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,18 @@ After completing any task that involves an architectural decision, a mistake fix
 
 Do this proactively — do not wait to be asked.
 
+## Security Review
+
+Run the `security-reviewer` agent (via `/security-review`) before every PR merge and before every Databricks deployment. This is mandatory, not optional.
+
+What to check:
+- No secrets, tokens, PAT tokens, passwords, or workspace URLs in committed files
+- No sensitive data in print/log statements
+- No PII in sample data or test fixtures
+- GitHub Secrets used for all credentials — never hardcoded
+
+If a security issue is found: fix it before merging. Never bypass with `--no-verify`.
+
 ## Verification
 
 Before considering a task done, verify:

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -18,9 +18,7 @@ Running DuckDB locally and Databricks in the cloud is the right pattern for a pe
 New data sources require zero code changes — add one YAML file, everything else flows automatically through `silver_runner` and `gold_runner`. This is the correct pattern for a metadata-driven platform.
 
 ### Dev/prd separation via separate workspaces (not catalogs)
-Initially planned to use two Unity Catalogs (`health_dw_dev` / `health_dw_prd`) within one workspace. Upgraded to two separate AWS Databricks workspaces:
-- dev: `dbc-23749322-8818.cloud.databricks.com`
-- prd: separate workspace (to be provisioned)
+Initially planned to use two Unity Catalogs (`health_dw_dev` / `health_dw_prd`) within one workspace. Upgraded to two separate AWS Databricks workspaces (URLs stored in `~/.databrickscfg` and GitHub Secrets — never committed to repo):
 - **Why**: separate workspaces give cleaner IAM, billing, and access isolation — closer to enterprise standard
 - **Catalog inside each workspace**: `health_dw` with schemas `bronze`, `silver`, `gold`
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md`: add mandatory **Security Review** section — `/security-review` must run before every PR merge and Databricks deployment
- `docs/learnings.md`: remove hardcoded workspace URL — stored in `~/.databrickscfg` and GitHub Secrets only, never in repo files
- `.gitignore`: plug two gaps found in security audit:
  - `.databricks-resources.json` (HIGH — untracked local Databricks state file)
  - `*.token` (MEDIUM — defensive pattern for token files)

## Security Review Findings (full run)
| Priority | Finding | Status |
|---|---|---|
| HIGH | Workspace URL in `databricks.yml` | Documented as accepted — URL alone is not a credential |
| HIGH | `.databricks-resources.json` not gitignored | Fixed in this PR |
| MEDIUM | `*.token` not in `.gitignore` | Fixed in this PR |
| LOW | Template injection risk in `silver_runner.py` | Documented in learnings as enterprise scale-up item |
| LOW | `claude.yml` broad permissions | Acceptable for personal repo |

## Test plan
- [ ] `.databricks-resources.json` no longer appears in `git status`
- [ ] GitHub Actions bundle validate passes
- [ ] `docs/learnings.md` contains no hardcoded workspace URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)