### PR TITLE
docs: Databricks MCP setup documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,11 @@ Workflow:
 4. Merge to main → auto-deploys to Databricks prd
 5. After merging: `git checkout main && git pull && git branch -d <branch>`
 
-Feature branches auto-deploy to Databricks dev on push (once secrets are configured).
+Feature branches should be deployed to dev before opening a PR:
+```bash
+cd health_unified_platform && databricks bundle deploy --target dev
+```
+This deploys directly from the feature branch — no merge to `main` required for dev testing.
 GitHub is configured to automatically delete remote head branches after merge.
 
 ## Productivity Tracking

--- a/docs/SETUP_DATABRICKS_MCP.md
+++ b/docs/SETUP_DATABRICKS_MCP.md
@@ -111,6 +111,17 @@ execute_sql: SELECT count(*) FROM health_dw.silver.heart_rate → 1,004,696 ✅
 
 This is a workflow convention — the MCP server has no technical lock. The `DATABRICKS_DEFAULT_CATALOG` env var documents the intended safe default.
 
+## Deploy workflow: feature branches → dev
+
+When working on feature branches, deploy changes directly to the dev environment before opening a PR:
+
+```bash
+# From health_unified_platform/
+databricks bundle deploy --target dev
+```
+
+This deploys the current branch's notebooks, jobs, and config to `health-platform-dev`. You do **not** need to merge to `main` first — dev deployments are safe to run from any branch. The GitHub Actions pipeline handles auto-deploy to prd after merging to `main`.
+
 ---
 
 ## Why self-hosted stdio vs Databricks Managed MCP


### PR DESCRIPTION
## Summary

- Documents self-hosted stdio MCP server already configured in `.mcp.json`
- Confirms catalog structure: `health-platform-dev` / `health-platform-prd` (new, active) + `health_dw` (legacy, has data)
- Adds dev/prd safety rule: all MCP queries default to dev; prd requires explicit confirmation
- Notes that feature branches should be deployed to dev via `bundle deploy --target dev` before PR
- Updated `CLAUDE.md` branching workflow with explicit dev deploy step

## Verification performed

- `get_current_user` → clauspetraeus@hotmail.com ✅
- `manage_uc_objects list catalogs` → health-platform-dev, health-platform-prd, health_dw confirmed ✅
- `SHOW SCHEMAS IN health-platform-dev` → bronze, silver, gold ✅
- `SELECT count(*) FROM health_dw.silver.heart_rate` → 1,004,696 rows ✅

## Test plan

- [ ] Review `docs/SETUP_DATABRICKS_MCP.md` for accuracy
- [ ] Confirm `CLAUDE.md` branching section is correct
- [ ] Verify bundle validate passes in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)