### PR TITLE
feat: AI governance framework + /prioritize command

### DIFF
--- a/.claude/commands/prioritize.md
+++ b/.claude/commands/prioritize.md
@@ -1,0 +1,59 @@
+# /prioritize — Merged Priority Ranking
+
+You are acting as a strategic prioritization assistant. Follow these steps exactly.
+
+## Step 1: Read both sources
+
+1. Read `~/TODO.md` — extract ALL `[ ]` items. Tag each with source=TODO and their section header (🔴 Nu, 🏥 HealthReporting, 💼 indie-products, etc.)
+2. Read `docs/PROJECT_PLAN.md` — extract ALL tasks with status `⬜ not started` or `🔵 in progress`. Tag each with source=PROJECT_PLAN and their phase.
+
+## Step 2: Classify each item
+
+Assign a priority tier:
+
+| Tier | Criteria |
+|------|----------|
+| **BLOCKER** | Explicitly marked as blocker, or required before another task can start |
+| **P0** | Strategic / income / momentum — items from TODO.md 🔴 section, or marked P0 |
+| **ACTIVE** | Currently in progress (🔵) in PROJECT_PLAN.md, or current phase tasks |
+| **P1** | High-value but not urgent — next sprint candidates |
+| **BACKLOG** | Everything else |
+
+## Step 3: Output ranked table
+
+Present a merged, deduplicated table:
+
+| Prioritet | Task | Kilde | Anbefalet nu? |
+|-----------|------|-------|---------------|
+| BLOCKER | ... | TODO / PROJECT_PLAN phase X | ✅ Ja |
+| P0 | ... | ... | ✅ Ja |
+| ACTIVE | ... | ... | 🔵 Allerede igangværende |
+| P1 | ... | ... | Næste sprint |
+| BACKLOG | ... | ... | Senere |
+
+Rules:
+- If the same task appears in both sources, show it once with source=BOTH
+- Do NOT include completed tasks (✅ done)
+- Do NOT include items from `## 🖥️ Mac Mini Setup`, `## 🤖 Claude Cowork`, `## 🛠️ Tools`, or `## 🎓 Learning` unless they are marked P0
+
+## Step 4: Top 3 for this session
+
+After the table, output:
+
+---
+
+### Top 3 for denne session
+
+Select 3 tasks that are:
+1. Not blocked by anything
+2. Highest strategic impact (income, momentum, or unblocking others)
+3. Completable in a single session
+
+Format:
+1. **[Task name]** — [1-sentence rationale] *(Kilde: TODO/PROJECT_PLAN)*
+2. ...
+3. ...
+
+---
+
+Do not start coding. This command is for planning and prioritization only.

--- a/docs/AI_GOVERNANCE.md
+++ b/docs/AI_GOVERNANCE.md
@@ -1,0 +1,83 @@
+# AI Governance Framework
+
+> PoC version — HealthReporting as blueprint
+> External reference: `~/ai-ledelse.md` (living document, updated independently)
+> Last updated: 2026-02-28
+
+---
+
+## Problem
+
+AI agents follow the nearest instruction, not overarching intent.
+
+Concrete symptom: `/plan-session` reads `docs/PROJECT_PLAN.md` and proposes technical backlog tasks — while `~/TODO.md` contains P0 strategic items (income, momentum, blockers) that are never surfaced. Result: the agent optimizes for the wrong thing.
+
+At team scale (50 developers, each with their own Claude Code), this diverges into 50 different architectures, conventions, and priorities. The question this framework answers: **how do you govern AI agents the same way you govern a software system?**
+
+---
+
+## What IS built (HealthReporting PoC)
+
+### 1. CLAUDE.md as constitution
+`CLAUDE.md` and `CLAUDE.local.md` define non-negotiable rules: language, branching, security, session protocol, commit discipline. The agent must follow these before any user instruction. This is the equivalent of a corporate code of conduct enforced at the tool level.
+
+### 2. Mandatory session protocol
+`CLAUDE.md` defines three lifecycle hooks:
+- `on_session_start` — read governance files, present sprint status, confirm scope before coding
+- `during_session` — automatic checkpoints after each major task
+- `on_session_end` — update CHANGELOG, PROJECT_PLAN, ARCHITECTURE before closing
+
+This prevents sessions from starting or ending without governance state being updated.
+
+### 3. Specialised agents (12 agents)
+`.claude/agents/` contains purpose-built agents with bounded scope:
+- `security-reviewer` — mandatory before every PR merge
+- `code-reviewer` — conventions + medallion quality check
+- `build-validator` — DAB bundle completeness
+- `medallion-reviewer`, `test-writer`, `yaml-config-writer`, etc.
+
+Specialisation prevents generalist agents from making broad, unchecked changes.
+
+### 4. MEMORY.md as cross-session context
+`~/.claude/projects/.../memory/MEMORY.md` persists architectural decisions, gotchas, and conventions across sessions. Without this, every session starts from scratch and re-discovers the same mistakes.
+
+### 5. /prioritize command (strategic → tactical bridge)
+`.claude/commands/prioritize.md` merges `~/TODO.md` (strategic backlog) with `docs/PROJECT_PLAN.md` (technical backlog) into a single ranked list. Ensures P0 items from TODO.md are surfaced alongside in-progress technical tasks. Closes the silo between strategic intent and agent execution.
+
+### 6. CI/CD as unenforced gate
+GitHub Actions (`deploy.yml`) runs bundle validation on every PR and auto-deploys to dev/prd on merge. This is a structural guardrail: broken bundles cannot deploy. It is not probabilistic — it is deterministic enforcement.
+
+---
+
+## Next level (not built yet)
+
+### code-reviewer as automatic PR gate
+Currently, `code-reviewer` is a manual slash command. The next step: run it as a GitHub Actions step on every PR, posting a structured review comment. The agent becomes a mandatory reviewer — not optional.
+
+### Claude Code hooks as enforcement layer
+`settings.json` supports pre/post tool-call hooks. Example: before every `git push`, run `/security-review`. Before every file write, validate against CLAUDE.md conventions. This moves governance from advisory to enforced.
+
+### Master agent (supervisor pattern)
+A supervisor agent that reads all governance MD files (CLAUDE.md, ARCHITECTURE.md, AI_GOVERNANCE.md, ai-ledelse.md) and acts as a guard rail for all other agents. Every sub-agent spawned by the master is bounded by the master's context. This is the "AI master agent" concept — one agent that knows the full architectural intent and can veto or redirect other agents.
+
+---
+
+## Open questions
+
+1. **Who owns CLAUDE.md in a team?** In a solo project, the developer owns it. In a team, it needs a review process — like a Terms of Service that all contributors accept.
+
+2. **Deterministic vs probabilistic governance?** CI/CD gates are deterministic (pass/fail). Agent-based review is probabilistic (good/bad judgment). The right architecture uses both: CI for structural rules, agents for contextual review.
+
+3. **How do you prevent CLAUDE.md drift?** If the file is never updated, it becomes stale. Need a process: after every architectural decision, update CLAUDE.md. This is currently manual — could be automated via `on_session_end`.
+
+4. **Cross-agent memory?** Currently, MEMORY.md is read by the main agent. Sub-agents (spawned via Task tool) do not inherit it. Shared memory across agent instances is an open problem.
+
+---
+
+## Reference
+
+- `~/ai-ledelse.md` — the living external document (updated independently, not committed to repo)
+- `CLAUDE.md` — primary governance file for this project
+- `.claude/commands/prioritize.md` — strategic/tactical bridge command
+- `.claude/agents/` — specialised agent definitions
+- `docs/PROJECT_PLAN.md` — Phase 7: AI Governance Framework tasks

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ---
 
+## 2026-02-28 — Session 003: AI Governance Framework
+
+**Phase:** Phase 7 (AI Governance) — new phase
+**Goal:** Struktureret kontrollag for AI-agenter — merger TODO.md + PROJECT_PLAN.md siloer
+
+### What was done
+- Added Phase 7: AI Governance Framework to docs/PROJECT_PLAN.md (10 tasks, 5 done, 5 planned)
+- Created docs/AI_GOVERNANCE.md — PoC governance framework document (problem, what IS built, next level, open questions)
+- Created .claude/commands/prioritize.md — slash command that merges ~/TODO.md + PROJECT_PLAN.md into ranked priority table with Top 3
+- Added ai-ledelse.md merge note to ~/TODO.md (outside repo)
+- Phase 7 Phase Overview row added to project plan table
+
+### What changed in architecture
+- New command: /prioritize — bridges strategic backlog (TODO.md) with technical backlog (PROJECT_PLAN.md)
+- New doc: docs/AI_GOVERNANCE.md — documents existing governance patterns + next-level roadmap
+- Project plan: Phase 7 added with 10 tasks covering AI agent governance
+
+### What's next
+- code-reviewer as automatic GitHub Actions PR gate
+- Claude Code hooks as enforcement layer
+- Master agent PoC (supervisor pattern)
+
+---
+
 ## 2026-02-28 — Session 002: Audit Framework + Governance Setup
 
 **Phase:** Phase 2 (Silver) + Phase 5 (Databricks) — parallel

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -16,6 +16,7 @@
 | 4 | Visualization & Reporting | ⬜ not started | Jun 2026 |
 | 5 | Cloud Migration (Databricks) | 🔵 in progress | Q2 2026 |
 | 6 | CI/CD & Automation | 🔵 in progress | Q2 2026 |
+| 7 | AI Governance Framework | 🔵 in progress | Q2 2026 |
 
 ---
 
@@ -135,3 +136,24 @@
 | Automated tests | ⬜ not started | pytest TDD framework |
 | Oura daily job (cron) | ⬜ not started | Automated bronze → silver pipeline |
 | Code-reviewer agent as PR gate | ⬜ not started | AI governance experiment |
+
+---
+
+## Phase 7 — AI Governance Framework
+
+**Goal:** Structured control layer for AI agents — ensuring agents follow strategic priorities (TODO.md), not just nearest instruction (PROJECT_PLAN.md). PoC showcase for enterprise Pandora context.
+
+| Task | Status | Notes |
+|------|--------|-------|
+| /prioritize command (merges TODO + PROJECT_PLAN) | ✅ done | .claude/commands/prioritize.md |
+| docs/AI_GOVERNANCE.md (internal governance framework) | ✅ done | PoC version of ~/ai-ledelse.md |
+| MEMORY.md cross-session context | ✅ done | ~/.claude/projects/.../memory/MEMORY.md |
+| Mandatory session protocol (CLAUDE.md) | ✅ done | on_session_start / during / end |
+| Specialised agents (12 agents) | ✅ done | code-reviewer, security-reviewer, build-validator, etc. |
+| CI/CD as unenforced gate (GitHub Actions) | ✅ done | deploy.yml — bundle validation + deploy |
+| code-reviewer agent as automatic PR gate | ⬜ not started | GitHub Actions step, not just manual slash command |
+| Claude Code hooks as enforcement layer | ⬜ not started | pre/post tool-call hooks in settings.json |
+| Master agent PoC (supervisor spawning sub-agents) | ⬜ not started | Reads all MD files, acts as architecture guard rail |
+| ai-ledelse.md merge (external → internal sync) | ⬜ not started | When ~/ai-ledelse.md updated externally, sync insights |
+
+**Exit criteria:** `/prioritize` produces a ranked Top 3 that reflects P0 strategic items from TODO.md — not just technical backlog from PROJECT_PLAN.md.


### PR DESCRIPTION
## Summary

- **docs/AI_GOVERNANCE.md** — PoC governance framework: documents what IS built (CLAUDE.md as constitution, session protocol, 12 agents, MEMORY.md, CI/CD gate, /prioritize) and what comes next (automatic PR gate, hooks, master agent). Includes open questions on team ownership and deterministic vs probabilistic governance.
- **.claude/commands/prioritize.md** — New `/prioritize` slash command that reads `~/TODO.md` + `docs/PROJECT_PLAN.md`, merges them into a ranked table (BLOCKER → P0 → ACTIVE → P1 → BACKLOG) and outputs a Top 3 for the session. Closes the silo where agents propose technical tasks while P0 strategic items go unsurfaced.
- **docs/PROJECT_PLAN.md** — Phase 7: AI Governance Framework added (10 tasks, 5 ✅ done, 5 ⬜ planned)
- **docs/CHANGELOG.md** — Session 003 entry

## Test plan

- [ ] Run `/prioritize` — confirm it reads both files and outputs ranked table with Top 3
- [ ] Run `/status` — confirm Phase 7 appears in overview
- [ ] Run `/plan-session` — confirm Phase 7 tasks appear as candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)