### PR TITLE
feat(governance): Claude Code hooks as enforcement layer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /Users/clauseduardpetraeus/HealthReporting/scripts/hooks/pre_commit_guard.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -18,6 +29,15 @@
           {
             "type": "command",
             "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q '\\.py\"'; then .venv/bin/black \"$(echo $CLAUDE_TOOL_INPUT | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null)\" --quiet 2>/dev/null || true; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /Users/clauseduardpetraeus/HealthReporting/scripts/hooks/post_commit.sh"
           }
         ]
       }

--- a/docs/AI_GOVERNANCE.md
+++ b/docs/AI_GOVERNANCE.md
@@ -196,6 +196,53 @@ Setup: `gh secret set ANTHROPIC_API_KEY` (interactive prompt, key never shown in
 ### Tier 4 — Human Review (highest trust)
 Human reviews PR with agent comments as input. Final approval always human.
 
+### Claude Code Hooks (Tier 0 — In-process enforcement)
+
+**Status: IMPLEMENTED**
+
+Claude Code hooks execute inside the agent's own process — before or after every tool call.
+Unlike CI/CD (which catches violations after commit), hooks catch violations at the moment of action.
+
+**Architecture:** `.claude/settings.json` → `scripts/hooks/`
+
+| Hook | Type | Trigger | Action |
+|------|------|---------|--------|
+| `pre_commit_guard.sh` | PreToolUse / Bash | `git commit` detected | Warn on direct main commits |
+| `post_commit.sh` | PostToolUse / Bash | `git commit` detected | Auto-run productivity tracker |
+| Black formatter | PostToolUse / Write\|Edit | `.py` file written | Auto-format Python (in-place) |
+
+**Hook execution model:**
+
+```
+Agent decides to call Bash("git commit -m ...")
+  ↓
+PreToolUse hook fires: pre_commit_guard.sh
+  → Checks branch: is it main?
+  → If main AND not productivity tracker: prints governance warning
+  → Exits 0 (soft enforcement) — tool is allowed to proceed
+  ↓
+Bash tool executes: git commit runs
+  ↓
+PostToolUse hook fires: post_commit.sh
+  → Detects 'git commit' in tool input
+  → Runs update_productivity.py automatically
+  → Prints: [GOVERNANCE] Productivity tracker updated after commit.
+```
+
+**Enforcement levels:**
+
+| Level | Mechanism | Override possible? |
+|-------|-----------|-------------------|
+| Exit 0 (warning) | Prints to model context — agent sees it | Yes (agent may ignore) |
+| Exit 2 (block) | Tool call is cancelled — command never runs | No (hard block) |
+
+Current hooks use exit 0 (warning level). Upgrade path: change exit 0 → exit 2 for hard blocks
+on specific violations (e.g., accidental `git push --force origin main`).
+
+**Why in-process hooks over pre-commit alone:**
+Pre-commit hooks only run on `git commit` — they miss agent actions that don't go through git.
+Claude Code hooks intercept every tool call, including: Write, Edit, Bash, WebFetch, MCP calls.
+
 ---
 
 ## Layer 4: Observability — What Is Happening?

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -163,7 +163,7 @@
 | docs/SPRINT_LOG.md (Layer 2) | ✅ done | Sprint planning and retrospectives |
 | AI_GOVERNANCE.md → full 7-layer framework | ✅ done | Rewritten from PoC to complete framework doc |
 | ANTHROPIC_API_KEY → GitHub Secrets | ⬜ not started | Manual: `gh secret set ANTHROPIC_API_KEY` |
-| Claude Code hooks as enforcement layer | ⬜ not started | pre/post tool-call hooks in settings.json |
+| Claude Code hooks as enforcement layer | ✅ done | pre_commit_guard.sh (PreToolUse) + post_commit.sh (PostToolUse) in scripts/hooks/ |
 | Master agent PoC (supervisor spawning sub-agents) | ⬜ not started | Reads all MD files, acts as architecture guard rail |
 | ai-ledelse.md merge (external → internal sync) | ⬜ not started | When ~/ai-ledelse.md updated externally, sync insights |
 

--- a/scripts/hooks/post_commit.sh
+++ b/scripts/hooks/post_commit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Layer 3 Enforcement Hook — PostToolUse / Bash
+# Runs automatically after any Bash tool call that contains 'git commit'.
+# Purpose: ensure productivity tracker is always updated after commits,
+#          even if the agent forgets to run it manually.
+#
+# Claude Code settings.json calls this script as a PostToolUse hook.
+# CLAUDE_TOOL_INPUT is set by Claude Code (JSON with 'command' field).
+
+set -euo pipefail
+
+REPO_ROOT="/Users/clauseduardpetraeus/HealthReporting"
+
+# Parse the command from the tool input
+CMD=$(echo "$CLAUDE_TOOL_INPUT" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('command',''))" 2>/dev/null \
+    || echo "")
+
+# Only act on git commit commands — skip if it's already the productivity tracker
+if echo "$CMD" | grep -q 'git commit' && ! echo "$CMD" | grep -q 'update_productivity'; then
+    cd "$REPO_ROOT"
+    if [ -f ".venv/bin/python" ] && [ -f "update_productivity.py" ]; then
+        .venv/bin/python update_productivity.py 2>/dev/null \
+            && echo "[GOVERNANCE] Productivity tracker updated after commit." \
+            || true
+    fi
+fi

--- a/scripts/hooks/pre_commit_guard.sh
+++ b/scripts/hooks/pre_commit_guard.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Layer 3 Enforcement Hook — PreToolUse / Bash
+# Runs before any Bash tool call. Warns when an agent is about to commit
+# directly to main — a violation of the branching strategy in CLAUDE.md.
+#
+# Exit 0: allow the tool call to proceed (soft enforcement — warning only)
+# Exit 2: block the tool call (not used here — reserved for hard enforcement)
+#
+# Exceptions allowed on main (per CLAUDE.md):
+#   - claude_code_productivity.json commits (tracking file, not code)
+#   - Changelog / productivity metric update commits
+
+REPO_ROOT="/Users/clauseduardpetraeus/HealthReporting"
+
+# Parse the command from the tool input
+CMD=$(echo "$CLAUDE_TOOL_INPUT" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('command',''))" 2>/dev/null \
+    || echo "")
+
+# Only check git commit commands
+if echo "$CMD" | grep -q 'git commit'; then
+    BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo "")
+
+    if [ "$BRANCH" = "main" ]; then
+        # Allow: productivity tracker and changelog-only commits
+        if ! echo "$CMD" | grep -qE \
+            '(claude_code_productivity|productivity metrics|Update productivity|chore.*productivity|chore: update productivity)'; then
+            echo ""
+            echo "GOVERNANCE WARNING: Direct commit to main detected."
+            echo "Per CLAUDE.md branching strategy, all feature work must use branches."
+            echo "  Allowed on main: claude_code_productivity.json updates"
+            echo "  Required for all other changes: git checkout -b feature/<name>"
+            echo ""
+        fi
+    fi
+fi
+
+# Always exit 0 — soft enforcement (warning, not blocking)
+exit 0


### PR DESCRIPTION
## Summary

Implements **Layer 3 Enforcement — Claude Code Hooks** (Phase 7 task).

In-process hooks intercept agent tool calls before/after execution — complementing CI/CD (catches violations post-commit) and pre-commit (catches violations at commit time).

### Hooks added

| Hook | Type | Trigger | Action |
|------|------|---------|--------|
| `pre_commit_guard.sh` | PreToolUse / Bash | `git commit` in command | Warns on direct main commits (soft, exit 0) |
| `post_commit.sh` | PostToolUse / Bash | `git commit` in command | Auto-runs productivity tracker |
| Black formatter | PostToolUse / Write\|Edit | `.py` file written | Auto-formats (existing) |

### Architecture

```
Agent: Bash("git commit -m ...")
  → PreToolUse: pre_commit_guard.sh runs → warns if on main (soft gate)
  → Bash executes: commit happens
  → PostToolUse: post_commit.sh runs → productivity tracker updated
```

### Files changed

- `.claude/settings.json` — added PreToolUse + Bash PostToolUse hooks
- `scripts/hooks/pre_commit_guard.sh` — main branch guard
- `scripts/hooks/post_commit.sh` — auto productivity tracker
- `docs/AI_GOVERNANCE.md` — documented Tier 0 hooks architecture
- `docs/PROJECT_PLAN.md` — marked Phase 7 task as done

## Test plan

- [x] `pre_commit_guard.sh`: warns on non-productivity commit to main
- [x] `pre_commit_guard.sh`: silent on productivity tracker commit to main
- [x] `pre_commit_guard.sh`: silent on feature branch commits
- [x] Both scripts exit 0 (soft enforcement)
- [x] `settings.json` is valid JSON
- [ ] GitHub Actions validate bundle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)