### PR TITLE
Fix filelock TOCTOU vulnerability (GHSA-qmgc-5h2g-mvrw)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ tzdata==2025.3
 urllib3==2.6.3
 zipp==3.23.0
 black==24.10.0
+filelock>=3.20.3
 # AI-native data model dependencies
 mcp>=1.0.0
 sentence-transformers>=2.2.0


### PR DESCRIPTION
## Summary
- Pin `filelock>=3.20.3` to resolve TOCTOU symlink race condition
- Transitive dependency via `sentence-transformers` -> `huggingface_hub`
- Caught by pip-audit in CI (added in PR #92)

## Test plan
- [ ] pip-audit passes in CI with no vulnerabilities

Generated with Claude Code