### PR TITLE
fix(quality): harden YAML validation and regex anchors

### DIFF
--- a/health_unified_platform/health_platform/mcp/health_tools.py
+++ b/health_unified_platform/health_platform/mcp/health_tools.py
@@ -584,7 +584,7 @@ class HealthTools:
         )
         return (today - timedelta(days=7), today)
 
-    _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+    _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*\Z")
 
     def _validate_identifier(self, name: str) -> str:
         """Validate that a string is a safe SQL identifier (prevents injection)."""

--- a/health_unified_platform/health_platform/quality/data_quality_checker.py
+++ b/health_unified_platform/health_platform/quality/data_quality_checker.py
@@ -19,7 +19,7 @@ from health_platform.utils.logging_config import get_logger
 
 logger = get_logger("data_quality_checker")
 
-_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*\Z")
 
 
 def _validate_id(name: str) -> str:

--- a/health_unified_platform/health_platform/quality/rule_loader.py
+++ b/health_unified_platform/health_platform/quality/rule_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,7 @@ from health_platform.utils.logging_config import get_logger
 logger = get_logger("rule_loader")
 
 _VALID_CHECK_TYPES = {"not_null", "unique", "freshness", "row_count", "value_range"}
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*\Z")
 
 _DEFAULT_RULES_PATH = (
     Path(__file__).resolve().parents[1]
@@ -59,18 +61,92 @@ def load_rules(rules_path: Path | None = None) -> dict[str, Any]:
 
 
 def _validate_rules(tables: dict[str, Any]) -> None:
-    """Validate that all check types in the rules are known."""
+    """Validate table names, check types, and value schemas at load time."""
     for table_name, checks in tables.items():
+        if not _SAFE_IDENTIFIER.match(table_name):
+            raise ValueError(
+                f"Invalid table name '{table_name}' -- "
+                f"must match [a-zA-Z_][a-zA-Z0-9_]*"
+            )
         if not isinstance(checks, dict):
             raise ValueError(
-                f"Table '{table_name}' rules must be a dict, got {type(checks).__name__}"
+                f"Table '{table_name}' rules must be a dict, "
+                f"got {type(checks).__name__}"
             )
-        for check_type in checks:
+        for check_type, check_value in checks.items():
             if check_type not in _VALID_CHECK_TYPES:
                 raise ValueError(
                     f"Unknown check type '{check_type}' for table '{table_name}'. "
                     f"Valid types: {', '.join(sorted(_VALID_CHECK_TYPES))}"
                 )
+            _validate_check_schema(table_name, check_type, check_value)
+
+
+def _validate_check_schema(table_name: str, check_type: str, check_value: Any) -> None:
+    """Validate the schema of a single check's configuration value."""
+    if check_type in ("not_null", "unique"):
+        if not isinstance(check_value, list) or not all(
+            isinstance(c, str) for c in check_value
+        ):
+            raise ValueError(
+                f"Table '{table_name}'.{check_type} must be a list of column names"
+            )
+        for col in check_value:
+            if not _SAFE_IDENTIFIER.match(col):
+                raise ValueError(f"Invalid column '{col}' in {table_name}.{check_type}")
+
+    elif check_type == "freshness":
+        if not isinstance(check_value, dict):
+            raise ValueError(
+                f"Table '{table_name}'.freshness must be a dict "
+                f"with 'column' and 'max_hours'"
+            )
+        if "column" not in check_value or "max_hours" not in check_value:
+            raise ValueError(
+                f"Table '{table_name}'.freshness requires "
+                f"'column' and 'max_hours' keys"
+            )
+        if not isinstance(check_value["max_hours"], (int, float)):
+            raise ValueError(
+                f"Table '{table_name}'.freshness.max_hours must be numeric, "
+                f"got {type(check_value['max_hours']).__name__}"
+            )
+        if not _SAFE_IDENTIFIER.match(check_value["column"]):
+            raise ValueError(
+                f"Invalid column '{check_value['column']}' "
+                f"in {table_name}.freshness"
+            )
+
+    elif check_type == "row_count":
+        if not isinstance(check_value, dict) or "min_rows" not in check_value:
+            raise ValueError(
+                f"Table '{table_name}'.row_count must be a dict with 'min_rows' key"
+            )
+        if not isinstance(check_value["min_rows"], (int, float)):
+            raise ValueError(
+                f"Table '{table_name}'.row_count.min_rows must be numeric, "
+                f"got {type(check_value['min_rows']).__name__}"
+            )
+
+    elif check_type == "value_range":
+        if not isinstance(check_value, dict):
+            raise ValueError(
+                f"Table '{table_name}'.value_range must be a dict of column ranges"
+            )
+        for col, bounds in check_value.items():
+            if not _SAFE_IDENTIFIER.match(col):
+                raise ValueError(f"Invalid column '{col}' in {table_name}.value_range")
+            if not isinstance(bounds, dict):
+                raise ValueError(
+                    f"Table '{table_name}'.value_range.{col} "
+                    f"must be a dict with min/max"
+                )
+            for key in ("min", "max"):
+                if key in bounds and not isinstance(bounds[key], (int, float)):
+                    raise ValueError(
+                        f"Table '{table_name}'.value_range.{col}.{key} "
+                        f"must be numeric, got {type(bounds[key]).__name__}"
+                    )
 
 
 def list_tables(rules_path: Path | None = None) -> list[str]:

--- a/tests/test_quality_rules_yaml.py
+++ b/tests/test_quality_rules_yaml.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+import yaml
 
 from health_platform.quality.rule_loader import load_rules, _VALID_CHECK_TYPES
 
@@ -85,3 +87,52 @@ class TestColumnConventions:
                     f"Table '{table_name}' freshness column '{col}' "
                     f"not in {valid_date_columns}"
                 )
+
+
+class TestSchemaValidation:
+    """Test that malformed YAML is rejected at load time."""
+
+    def _write_rules(self, tmp_path, tables_dict):
+        path = tmp_path / "bad_rules.yaml"
+        path.write_text(yaml.dump({"tables": tables_dict}))
+        return path
+
+    def test_rejects_invalid_table_name(self, tmp_path):
+        path = self._write_rules(tmp_path, {"bad table;": {"not_null": ["col"]}})
+        with pytest.raises(ValueError, match="Invalid table name"):
+            load_rules(path)
+
+    def test_rejects_non_numeric_max_hours(self, tmp_path):
+        path = self._write_rules(
+            tmp_path,
+            {"good_table": {"freshness": {"column": "day", "max_hours": "banana"}}},
+        )
+        with pytest.raises(ValueError, match="must be numeric"):
+            load_rules(path)
+
+    def test_rejects_non_numeric_row_count_min(self, tmp_path):
+        path = self._write_rules(
+            tmp_path, {"good_table": {"row_count": {"min_rows": "lots"}}}
+        )
+        with pytest.raises(ValueError, match="must be numeric"):
+            load_rules(path)
+
+    def test_rejects_non_numeric_value_range_bound(self, tmp_path):
+        path = self._write_rules(
+            tmp_path,
+            {"good_table": {"value_range": {"score": {"min": "low", "max": 100}}}},
+        )
+        with pytest.raises(ValueError, match="must be numeric"):
+            load_rules(path)
+
+    def test_rejects_invalid_column_in_not_null(self, tmp_path):
+        path = self._write_rules(
+            tmp_path, {"good_table": {"not_null": ["valid_col", "bad col;"]}}
+        )
+        with pytest.raises(ValueError, match="Invalid column"):
+            load_rules(path)
+
+    def test_rejects_trailing_newline_in_table_name(self, tmp_path):
+        path = self._write_rules(tmp_path, {"daily_sleep\n": {"not_null": ["col"]}})
+        with pytest.raises(ValueError, match="Invalid table name"):
+            load_rules(path)


### PR DESCRIPTION
## Summary
- Fix regex `$` → `\Z` anchor in SQL identifier validation (3 files)
- Add load-time YAML schema validation: type-check all config values, validate table/column identifiers
- 6 new tests for malformed YAML rejection

Addresses findings from security review and AI review (Claude + Gemini) of A2.

## Test plan
- [x] 28/28 DQ tests pass
- [x] No regressions in full test suite

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>