### PR TITLE
feat(api): add mobile sync and thresholds endpoints for DS3

### DIFF
--- a/health_unified_platform/health_platform/api/routes/mobile.py
+++ b/health_unified_platform/health_platform/api/routes/mobile.py
@@ -1,0 +1,244 @@
+"""Mobile-optimized endpoints for the Laege i Lommen iOS app.
+
+Provides bulk data sync and metric thresholds for efficient mobile access.
+Minimizes round-trips: one call replaces multiple endpoint calls.
+
+Routes:
+    GET /v1/mobile/sync?since=<ISO timestamp>  — bulk data sync
+    GET /v1/mobile/thresholds                   — metric threshold definitions
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+from fastapi import APIRouter, Depends, Query
+
+from health_platform.api.auth import verify_token
+from health_platform.mcp.query_builder import QueryBuilder
+from health_platform.utils.logging_config import get_logger
+
+logger = get_logger("api.mobile")
+
+router = APIRouter(prefix="/v1/mobile", tags=["mobile"])
+
+# Contracts directory for threshold parsing
+_CONTRACTS_DIR = Path(__file__).resolve().parents[2] / "contracts" / "metrics"
+
+# Metrics to include in bulk sync (core dashboard metrics)
+_SYNC_METRICS = {
+    "sleep_score": {
+        "table": "silver.daily_sleep",
+        "columns": ["day", "sleep_score"],
+    },
+    "readiness_score": {
+        "table": "silver.daily_readiness",
+        "columns": ["day", "readiness_score"],
+    },
+    "steps": {
+        "table": "silver.daily_activity",
+        "columns": ["day", "steps"],
+    },
+    "activity_score": {
+        "table": "silver.daily_activity",
+        "columns": ["day", "activity_score"],
+    },
+    "resting_heart_rate": {
+        "table": "silver.heart_rate",
+        "columns": ["day", "resting_heart_rate"],
+    },
+    "weight": {
+        "table": "silver.weight",
+        "columns": ["datetime", "weight_kg"],
+    },
+    "daily_stress": {
+        "table": "silver.daily_stress",
+        "columns": ["day", "day_summary", "stress_high", "recovery_high"],
+    },
+}
+
+
+def _get_db_path() -> str:
+    """Resolve DuckDB database path from environment."""
+    if path := os.environ.get("HEALTH_DB_PATH"):
+        return path
+    env = os.environ.get("HEALTH_ENV", "dev")
+    return str(Path.home() / "health_dw" / f"health_dw_{env}.db")
+
+
+def _get_connection() -> duckdb.DuckDBPyConnection:
+    """Create a read-only DuckDB connection."""
+    return duckdb.connect(_get_db_path(), read_only=True)
+
+
+def _parse_since(since: Optional[str]) -> date:
+    """Parse the 'since' parameter into a date. Defaults to 30 days ago."""
+    if not since:
+        return date.today() - timedelta(days=30)
+    try:
+        return datetime.fromisoformat(since).date()
+    except ValueError:
+        return date.today() - timedelta(days=30)
+
+
+def _query_metric(
+    con: duckdb.DuckDBPyConnection, table: str, columns: list[str], since: date
+) -> list[dict]:
+    """Query a single metric table and return rows as dicts."""
+    col_list = ", ".join(columns)
+    # Determine the date column (first column)
+    date_col = columns[0]
+    sql = f"SELECT {col_list} FROM {table} WHERE {date_col} >= ? ORDER BY {date_col}"
+    try:
+        result = con.execute(sql, [since]).fetchall()
+        col_names = [c[0] for c in con.description]
+        rows = []
+        for row in result:
+            row_dict = {}
+            for i, col in enumerate(col_names):
+                val = row[i]
+                # Convert date/datetime to ISO string
+                if isinstance(val, (date, datetime)):
+                    val = val.isoformat()
+                row_dict[col] = val
+            rows.append(row_dict)
+        return rows
+    except duckdb.CatalogException:
+        logger.debug("Table %s not found, skipping", table)
+        return []
+    except Exception:
+        logger.debug("Failed to query %s", table, exc_info=True)
+        return []
+
+
+def _get_profile(con: duckdb.DuckDBPyConnection) -> dict:
+    """Load patient profile as structured dict."""
+    try:
+        result = con.execute(
+            "SELECT category, profile_key, profile_value "
+            "FROM agent.patient_profile ORDER BY category, profile_key"
+        ).fetchall()
+        profile = {}
+        for category, key, value in result:
+            if category not in profile:
+                profile[category] = {}
+            profile[category][key] = value
+        return profile
+    except Exception:
+        logger.debug("Failed to load patient profile", exc_info=True)
+        return {}
+
+
+def _get_daily_summaries(con: duckdb.DuckDBPyConnection, since: date) -> list[dict]:
+    """Load daily summaries since a given date."""
+    try:
+        result = con.execute(
+            "SELECT day, summary_text FROM agent.daily_summaries "
+            "WHERE day >= ? ORDER BY day",
+            [since],
+        ).fetchall()
+        return [
+            {
+                "day": row[0].isoformat() if isinstance(row[0], date) else str(row[0]),
+                "summary_text": row[1],
+            }
+            for row in result
+        ]
+    except Exception:
+        logger.debug("Failed to load daily summaries", exc_info=True)
+        return []
+
+
+def _get_alerts(con: duckdb.DuckDBPyConnection) -> list[dict]:
+    """Get recent anomaly alerts from daily summaries."""
+    try:
+        result = con.execute(
+            "SELECT day, anomaly_metrics FROM agent.daily_summaries "
+            "WHERE has_anomaly = true AND day >= CURRENT_DATE - 7 "
+            "ORDER BY day DESC"
+        ).fetchall()
+        return [
+            {
+                "day": row[0].isoformat() if isinstance(row[0], date) else str(row[0]),
+                "anomaly_metrics": row[1],
+            }
+            for row in result
+        ]
+    except Exception:
+        logger.debug("Failed to load alerts", exc_info=True)
+        return []
+
+
+@router.get("/sync")
+async def sync(
+    since: Optional[str] = Query(
+        None,
+        description="ISO timestamp — sync data since this point. Defaults to 30 days ago.",
+    ),
+    _token: str = Depends(verify_token),
+):
+    """Bulk data sync for mobile app.
+
+    Returns all dashboard metrics, patient profile, alerts, and daily
+    summaries in a single response. Replaces 4+ separate API calls.
+    """
+    since_date = _parse_since(since)
+    con = _get_connection()
+
+    try:
+        # Fetch all metrics
+        metrics = {}
+        for metric_name, config in _SYNC_METRICS.items():
+            rows = _query_metric(con, config["table"], config["columns"], since_date)
+            if rows:
+                metrics[metric_name] = rows
+
+        # Fetch profile, summaries, alerts
+        profile = _get_profile(con)
+        summaries = _get_daily_summaries(con, since_date)
+        alerts = _get_alerts(con)
+    finally:
+        con.close()
+
+    return {
+        "metrics": metrics,
+        "profile": profile,
+        "alerts": alerts,
+        "daily_summaries": summaries,
+        "sync_timestamp": datetime.now().isoformat(),
+    }
+
+
+@router.get("/thresholds")
+async def thresholds(
+    _token: str = Depends(verify_token),
+):
+    """Metric threshold definitions for UI coloring.
+
+    Parses all YAML semantic contracts and returns the thresholds
+    section for each metric. Loaded once by the mobile app, cached
+    indefinitely on-device.
+    """
+    qb = QueryBuilder(_CONTRACTS_DIR)
+    metric_names = qb.list_metrics()
+
+    result = {}
+    for name in metric_names:
+        try:
+            contract = qb.load_contract(name)
+            metric_def = contract.get("metric", contract)
+            thresh = metric_def.get("thresholds")
+            if thresh:
+                result[name] = thresh
+        except Exception:
+            logger.debug("Failed to load thresholds for %s", name, exc_info=True)
+
+    return {
+        "thresholds": result,
+        "metric_count": len(result),
+        "timestamp": datetime.now().isoformat(),
+    }

--- a/health_unified_platform/health_platform/api/server.py
+++ b/health_unified_platform/health_platform/api/server.py
@@ -61,6 +61,11 @@ from health_platform.api.chat_ui import router as chat_ui_router  # noqa: E402
 
 app.include_router(chat_ui_router)
 
+# Mount mobile endpoints (bulk sync, thresholds)
+from health_platform.api.routes.mobile import router as mobile_router  # noqa: E402
+
+app.include_router(mobile_router)
+
 
 def _get_tools(read_only: bool = True) -> HealthTools:
     """Create a fresh HealthTools instance."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -370,3 +370,108 @@ class TestAlertsEndpoint:
         data = response.json()
         assert "alerts" in data
         assert isinstance(data["alerts"], list)
+
+
+class TestMobileSyncEndpoint:
+    """Tests for GET /v1/mobile/sync — bulk data sync for mobile app."""
+
+    def test_sync_returns_all_sections(self, client):
+        response = client.get("/v1/mobile/sync", headers=AUTH_HEADERS)
+        assert response.status_code == 200
+        data = response.json()
+        assert "metrics" in data
+        assert "profile" in data
+        assert "alerts" in data
+        assert "daily_summaries" in data
+        assert "sync_timestamp" in data
+
+    def test_sync_contains_sleep_data(self, client):
+        response = client.get("/v1/mobile/sync", headers=AUTH_HEADERS)
+        data = response.json()
+        assert "sleep_score" in data["metrics"]
+        sleep_rows = data["metrics"]["sleep_score"]
+        assert len(sleep_rows) == 7
+        assert sleep_rows[0]["sleep_score"] == 82
+
+    def test_sync_contains_steps_data(self, client):
+        response = client.get("/v1/mobile/sync", headers=AUTH_HEADERS)
+        data = response.json()
+        assert "steps" in data["metrics"]
+        step_rows = data["metrics"]["steps"]
+        assert len(step_rows) == 3
+        assert step_rows[0]["steps"] == 12450
+
+    def test_sync_contains_profile(self, client):
+        response = client.get("/v1/mobile/sync", headers=AUTH_HEADERS)
+        data = response.json()
+        profile = data["profile"]
+        assert "demographics" in profile
+        assert profile["demographics"]["biological_sex"] == "male"
+
+    def test_sync_contains_daily_summaries(self, client):
+        response = client.get("/v1/mobile/sync", headers=AUTH_HEADERS)
+        data = response.json()
+        summaries = data["daily_summaries"]
+        assert len(summaries) >= 1
+        assert "Good sleep" in summaries[0]["summary_text"]
+
+    def test_sync_since_parameter_filters(self, client):
+        response = client.get(
+            "/v1/mobile/sync",
+            params={"since": "2026-02-25T00:00:00"},
+            headers=AUTH_HEADERS,
+        )
+        data = response.json()
+        sleep_rows = data["metrics"]["sleep_score"]
+        # Only 2026-02-25 and 2026-02-26 should remain
+        assert len(sleep_rows) == 2
+
+    def test_sync_requires_auth(self, client):
+        response = client.get("/v1/mobile/sync")
+        assert response.status_code in (401, 403)
+
+    def test_sync_invalid_since_uses_default(self, client):
+        response = client.get(
+            "/v1/mobile/sync",
+            params={"since": "not-a-date"},
+            headers=AUTH_HEADERS,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "metrics" in data
+
+
+class TestMobileThresholdsEndpoint:
+    """Tests for GET /v1/mobile/thresholds — metric threshold definitions."""
+
+    def test_thresholds_returns_data(self, client):
+        response = client.get("/v1/mobile/thresholds", headers=AUTH_HEADERS)
+        assert response.status_code == 200
+        data = response.json()
+        assert "thresholds" in data
+        assert "metric_count" in data
+        assert "timestamp" in data
+
+    def test_thresholds_contains_sleep_score(self, client):
+        response = client.get("/v1/mobile/thresholds", headers=AUTH_HEADERS)
+        data = response.json()
+        thresholds = data["thresholds"]
+        assert "sleep_score" in thresholds
+        assert "optimal" in thresholds["sleep_score"]
+        assert thresholds["sleep_score"]["optimal"]["min"] == 85
+
+    def test_thresholds_contains_steps(self, client):
+        response = client.get("/v1/mobile/thresholds", headers=AUTH_HEADERS)
+        data = response.json()
+        thresholds = data["thresholds"]
+        assert "steps" in thresholds
+        assert thresholds["steps"]["optimal"]["min"] == 10000
+
+    def test_thresholds_has_multiple_metrics(self, client):
+        response = client.get("/v1/mobile/thresholds", headers=AUTH_HEADERS)
+        data = response.json()
+        assert data["metric_count"] >= 10
+
+    def test_thresholds_requires_auth(self, client):
+        response = client.get("/v1/mobile/thresholds")
+        assert response.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- Add `GET /v1/mobile/sync?since=<ISO>` — bulk data sync (metrics, profile, alerts, summaries in one call)
- Add `GET /v1/mobile/thresholds` — metric threshold definitions from YAML contracts for UI coloring
- New route file: `health_platform/api/routes/mobile.py`
- 13 new tests (27 total passing)

These endpoints support the Laege i Lommen iOS app (DS3) by minimizing round-trips over Tailscale VPN.

## Test plan
- [x] 27/27 tests pass (`pytest tests/test_api.py -v`)
- [x] Pre-commit hooks pass (black, ruff, gitleaks)
- [x] Security review completed — no issues in backend code

Generated with Claude Code