### PR TITLE
fix(config): add missing bronze source refs for A6+A7 tables

### DIFF
--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/_sources.yml
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/_sources.yml
@@ -9,3 +9,14 @@ sources:
       - name: stg_oura_blood_oxygen
       - name: stg_withings_blood_pressure
       - name: stg_withings_weight
+      - name: stg_oura_csv_dailyresilience
+      - name: stg_oura_csv_dailycardiovascularage
+      - name: stg_oura_csv_daytimestress
+      - name: stg_oura_csv_temperature
+      - name: stg_oura_csv_sleeptime
+      - name: stg_oura_csv_enhancedtag
+      - name: stg_oura_csv_sleepmodel
+      - name: stg_withings_signal
+      - name: stg_withings_pwv
+      - name: stg_withings_sleep
+      - name: stg_withings_body_temperature


### PR DESCRIPTION
## Summary
- Add 11 missing bronze source references to `_sources.yml` for Oura CSV and Withings tables
- These were missed in the A6+A7 merge (PR #109)
- All 63 A6+A7 silver tests pass, 538 total tests pass

## Test plan
- [x] `pytest tests/test_silver_oura_csv.py tests/test_silver_withings.py tests/test_silver_shared_tables.py` — 63 passed
- [x] Full suite: 538 passed (3 pre-existing failures unrelated)

Generated with Claude Code