### PR TITLE
docs: add draw.io C4 architecture diagrams

### DIFF
--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -2,7 +2,7 @@
 
 > Solution architecture narrative + C4 diagrams (Level 1–3).
 > For detailed tables, file structure, and technology stack, see [ARCHITECTURE.md](./ARCHITECTURE.md).
-> For an interactive view, see [architecture-diagram.html](./architecture-diagram.html).
+> For editable diagrams, open the `.drawio` files in draw.io desktop app — see [Draw.io Diagrams](#draw-io-diagrams-editable) section.
 
 ---
 
@@ -26,7 +26,7 @@ This split exists because Gold encodes assumptions about what questions will be 
 ### Key Properties
 
 1. **Metadata-driven** — adding a new data source requires a YAML config entry, not code changes ([ADR-003](./adr/ADR-003-yaml-driven-pipeline.md))
-2. **MCP-first** — AI never writes raw SQL. All data access goes through 8 typed MCP tools with semantic contracts
+2. **MCP-first** — AI never writes raw SQL. All data access goes through 17 typed MCP tools with semantic contracts
 3. **Schema-as-documentation** — every column across 21 silver tables has a `COMMENT ON` description. The schema IS the AI's user interface (83% query accuracy vs 40% without)
 4. **DuckDB local-first** — zero-config OLAP runtime, Parquet interchange format, single-writer simplicity ([ADR-001](./adr/ADR-001-duckdb-local-runtime.md))
 5. **Medallion foundation** — Bronze → Silver shared across both stacks, source isolation via `source_system` column ([ADR-002](./adr/ADR-002-medallion-architecture.md))
@@ -93,10 +93,10 @@ C4Container
         Container(connectors, "Source Connectors", "Python", "Oura OAuth client, Apple Health XML parser, CSV-to-Parquet converter")
         Container(ingestion, "Ingestion Engine", "Python", "Reads sources_config.yaml, loads Parquet into Bronze tables")
         Container(dbt_merge, "dbt + Merge Runner", "Python/SQL", "Schema creation (dbt) + MERGE INTO (SQL scripts)")
-        Container(ai_modules, "AI Modules", "Python", "Text generation, embeddings, baselines, correlations")
+        Container(ai_modules, "AI Modules", "Python", "8 modules: text gen, embeddings, baselines, correlations, anomaly, recommendations, trends, notifications")
         Container(agent_memory, "Agent Memory", "DuckDB schema", "patient_profile, daily_summaries, health_graph, knowledge_base")
         Container(contracts, "Semantic Contracts", "YAML", "18 metric definitions + business rules + master index")
-        Container(mcp, "MCP Server", "Python/FastMCP", "8 typed tools — primary AI data access layer")
+        Container(mcp, "MCP Server", "Python/FastMCP", "17 typed tools — primary AI data access layer")
         Container(api, "FastAPI REST Server", "Python", "5 endpoints, Bearer auth, Tailscale-accessible")
         Container(sync, "Daily Sync", "Bash/launchd", "Oura fetch → Bronze → Silver → Summary at 06:00")
         ContainerDb(duckdb, "DuckDB Database", "DuckDB", "bronze, silver, agent schemas")
@@ -160,7 +160,7 @@ C4Component
     Person(claude, "Claude Code", "AI agent")
 
     Boundary(mcp_boundary, "MCP Server (FastMCP)") {
-        Component(server, "server.py", "FastMCP", "Server entrypoint — registers 8 tools")
+        Component(server, "server.py", "FastMCP", "Server entrypoint — registers 17 tools")
         Component(health_tools, "health_tools.py", "Python", "Tool implementations — query routing, memory ops, insight recording")
         Component(query_builder, "query_builder.py", "Python", "YAML contract → parameterized SQL generation")
         Component(formatter, "formatter.py", "Python", "Query results → markdown output formatting")
@@ -208,10 +208,25 @@ C4Component
 
 ---
 
+## Draw.io Diagrams (Editable)
+
+For editable, high-fidelity versions of these diagrams, open the `.drawio` files in [diagrams.net](https://app.diagrams.net):
+
+| File | Diagram | Description |
+|------|---------|-------------|
+| [`c4-level1-context.drawio`](./c4-level1-context.drawio) | C4 Level 1 | System Context — actors + external systems |
+| [`c4-level2-containers.drawio`](./c4-level2-containers.drawio) | C4 Level 2 | Container Diagram — local + cloud stack containers |
+| [`c4-level3-components.drawio`](./c4-level3-components.drawio) | C4 Level 3 | Component Diagram — AI-native data access layer zoom |
+| [`solution-architecture.drawio`](./solution-architecture.drawio) | Solution Architecture | End-to-end numbered flow (14 steps) |
+
+These draw.io files reflect the current state: 17 MCP tools, 8 AI modules, 9 source connectors, 24 semantic contracts.
+
+---
+
 ## Maintenance Notes
 
 - **When to update these diagrams:** When a new data source connector is added, a new MCP tool is created, or the dual-stack boundary changes (e.g., new cloud services or local components).
 - **For detailed tables** (bronze/silver/gold contents, file paths, technology stack): see [ARCHITECTURE.md](./ARCHITECTURE.md).
-- **For interactive exploration:** see [architecture-diagram.html](./architecture-diagram.html).
+- **Draw.io files:** Open `.drawio` files in the draw.io desktop app or [diagrams.net](https://app.diagrams.net) — editable and exportable to PNG/SVG/PDF. Draw.io is the standard tool for architecture diagrams in this project.
 - **Rendering:** GitHub renders Mermaid natively. For complex diagrams, use the [Mermaid Live Editor](https://mermaid.live) if nested boundaries render unexpectedly.
 - **C4 plugin:** These diagrams use Mermaid's C4 extension (`C4Context`, `C4Container`, `C4Component`). Ensure your viewer supports C4 syntax.

--- a/docs/c4-level1-context.drawio
+++ b/docs/c4-level1-context.drawio
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-03-11">
+  <diagram id="c4-level1" name="C4 Level 1 — System Context">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ======================== -->
+        <!-- PERSONS (top-left)       -->
+        <!-- ======================== -->
+
+        <!-- Claus -->
+        <mxCell id="2" value="Claus&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Developer and data owner&lt;/font&gt;" style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="80" y="80" width="140" height="140" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code -->
+        <mxCell id="3" value="Claude Code&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;AI agent — primary local&lt;br&gt;data consumer&lt;/font&gt;" style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="280" y="80" width="140" height="140" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- INTERNAL SYSTEM (center)           -->
+        <!-- ================================== -->
+
+        <mxCell id="4" value="&lt;b&gt;HealthReporting Platform&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Dual-stack health data platform:&lt;br&gt;AI-native locally, traditional medallion in cloud&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="430" y="370" width="300" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- DATA SOURCES — ACTIVE (right, green) -->
+        <!-- ================================== -->
+
+        <!-- Oura API -->
+        <mxCell id="5" value="Oura API&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Sleep, activity, readiness,&lt;br&gt;HR, SpO2, stress&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="60" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Apple Health -->
+        <mxCell id="6" value="Apple Health&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;HR, steps, temperature, respiratory,&lt;br&gt;energy, gait, mindfulness, water&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="150" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Lifesum -->
+        <mxCell id="7" value="Lifesum&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Nutrition and meal tracking&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="240" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- DATA SOURCES — PLANNED (right, gray) -->
+        <!-- ================================== -->
+
+        <!-- Withings API -->
+        <mxCell id="8" value="Withings API&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Blood pressure, weight&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#666666;fontSize=12;fontFamily=Helvetica;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="900" y="340" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Strava API -->
+        <mxCell id="9" value="Strava API&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Workout activities&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#666666;fontSize=12;fontFamily=Helvetica;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="900" y="430" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- sundhed.dk -->
+        <mxCell id="10" value="sundhed.dk&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Medical records&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#666666;fontSize=12;fontFamily=Helvetica;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="900" y="520" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- DATA SOURCES — ACTIVE (right, green, lower) -->
+        <!-- ================================== -->
+
+        <!-- Weather API -->
+        <mxCell id="11" value="Weather API&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Temperature, humidity, pressure&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="620" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Genetics -->
+        <mxCell id="12" value="Genetics&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;SNP data, PRS scores&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="710" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Lab Results -->
+        <mxCell id="13" value="Lab Results&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Blood biomarkers&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="900" y="800" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- INFRASTRUCTURE (bottom, green)     -->
+        <!-- ================================== -->
+
+        <!-- Databricks -->
+        <mxCell id="14" value="Databricks&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Unity Catalog, Delta Lake,&lt;br&gt;Workflows, Dashboards&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="120" y="600" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- GitHub -->
+        <mxCell id="15" value="GitHub&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Source control, Actions CI/CD,&lt;br&gt;Projects board&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="120" y="700" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Tailscale -->
+        <mxCell id="16" value="Tailscale&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;VPN mesh for remote&lt;br&gt;API access&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="380" y="600" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ntfy.sh -->
+        <mxCell id="17" value="ntfy.sh&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Push notifications for&lt;br&gt;pipeline status&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="380" y="700" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- EDGES — Persons to System          -->
+        <!-- ================================== -->
+
+        <!-- Claus → HealthReporting -->
+        <mxCell id="30" value="Manages, configures, reviews" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="2" target="4" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code → HealthReporting -->
+        <mxCell id="31" value="Queries via MCP tools&lt;br&gt;and REST API" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="3" target="4" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- EDGES — System to Data Sources     -->
+        <!-- ================================== -->
+
+        <!-- HealthReporting → Oura API -->
+        <mxCell id="32" value="OAuth 2.0" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="5" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Apple Health -->
+        <mxCell id="33" value="XML export" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Lifesum -->
+        <mxCell id="34" value="CSV export" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Withings API -->
+        <mxCell id="35" value="OAuth 2.0 (planned)" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;dashed=1;" edge="1" source="4" target="8" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Strava API -->
+        <mxCell id="36" value="OAuth 2.0 (planned)" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;dashed=1;" edge="1" source="4" target="9" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → sundhed.dk -->
+        <mxCell id="37" value="Playwright + MitID (planned)" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;dashed=1;" edge="1" source="4" target="10" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Weather API -->
+        <mxCell id="38" value="REST API" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="11" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Genetics -->
+        <mxCell id="39" value="CSV import" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="12" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Lab Results -->
+        <mxCell id="40" value="CSV import" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="13" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ================================== -->
+        <!-- EDGES — System to Infrastructure   -->
+        <!-- ================================== -->
+
+        <!-- HealthReporting → Databricks -->
+        <mxCell id="41" value="Deploys bundles,&lt;br&gt;runs cloud pipelines" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="14" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → GitHub -->
+        <mxCell id="42" value="CI/CD, PR validation" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="15" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → Tailscale -->
+        <mxCell id="43" value="Exposes API over VPN" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="16" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- HealthReporting → ntfy.sh -->
+        <mxCell id="44" value="Sends notifications" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=10;fontFamily=Helvetica;" edge="1" source="4" target="17" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/c4-level2-containers.drawio
+++ b/docs/c4-level2-containers.drawio
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-03-11">
+  <diagram id="c4-level2" name="C4 Level 2 — Container Diagram">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1800" pageHeight="1200" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ======================== -->
+        <!-- PERSONS (top-left)       -->
+        <!-- ======================== -->
+
+        <!-- Claus -->
+        <mxCell id="person-claus" value="&lt;b&gt;Claus&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;Developer&lt;/font&gt;" style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="100" y="20" width="100" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code -->
+        <mxCell id="person-claude" value="&lt;b&gt;Claude Code&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:10px;&quot;&gt;AI agent&lt;/font&gt;" style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="280" y="20" width="100" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- EXTERNAL SOURCES (top)   -->
+        <!-- ======================== -->
+
+        <mxCell id="ext-oura" value="&lt;b&gt;Oura API&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="520" y="30" width="120" height="40" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="ext-apple" value="&lt;b&gt;Apple Health&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="660" y="30" width="120" height="40" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="ext-lifesum" value="&lt;b&gt;Lifesum&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="800" y="30" width="120" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- LOCAL STACK BOUNDARY (left, blue dashed)      -->
+        <!-- ============================================= -->
+
+        <mxCell id="boundary-local" value="&lt;b&gt;Local Stack (Mac Mini M4)&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#DCEEFB;strokeColor=#1F6FEB;verticalAlign=top;fontStyle=1;fontSize=14;fontFamily=Helvetica;container=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="160" width="720" height="830" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 1: Source Connectors + Daily Sync -->
+
+        <mxCell id="c-source-connectors" value="&lt;b&gt;Source Connectors&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;9 connectors: Oura OAuth, Apple Health&lt;br&gt;XML, Lifesum CSV, Withings, Strava,&lt;br&gt;sundhed.dk, Weather, Genetics, Lab&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="50" width="250" height="100" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="c-daily-sync" value="&lt;b&gt;Daily Sync&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Bash/launchd]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Orchestrates at 06:00&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="540" y="50" width="150" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 2: Parquet Data Lake -->
+
+        <mxCell id="c-parquet" value="&lt;b&gt;Parquet Data Lake&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Hive-partitioned]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Hive-partitioned raw files&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="180" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 2: Ingestion Engine -->
+
+        <mxCell id="c-ingestion" value="&lt;b&gt;Ingestion Engine&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Reads sources_config.yaml,&lt;br&gt;loads Parquet into Bronze&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="280" y="180" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 3: DuckDB (center) -->
+
+        <mxCell id="c-duckdb" value="&lt;b&gt;DuckDB&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;bronze, silver, agent schemas&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary-local">
+          <mxGeometry x="250" y="300" width="180" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 3: dbt + Merge Runner (right of DuckDB) -->
+
+        <mxCell id="c-dbt" value="&lt;b&gt;dbt + Merge Runner&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python/SQL]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Schema creation (dbt) +&lt;br&gt;MERGE INTO (SQL scripts)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="490" y="290" width="200" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 3: Quality Engine (left of DuckDB) -->
+
+        <mxCell id="c-quality" value="&lt;b&gt;Quality Engine&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Data quality checker&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="310" width="170" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 4: AI Modules -->
+
+        <mxCell id="c-ai-modules" value="&lt;b&gt;AI Modules&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;8 modules: text gen, embeddings,&lt;br&gt;baselines, correlations, anomaly,&lt;br&gt;recommendations, trends, notifications&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#388E3C;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="420" width="250" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 4: Agent Memory -->
+
+        <mxCell id="c-agent-memory" value="&lt;b&gt;Agent Memory&lt;/b&gt;&lt;br&gt;&lt;i&gt;[DuckDB schema]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;patient_profile, daily_summaries,&lt;br&gt;health_graph, knowledge_base&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="320" y="420" width="210" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 4: Semantic Contracts -->
+
+        <mxCell id="c-semantic" value="&lt;b&gt;Semantic Contracts&lt;/b&gt;&lt;br&gt;&lt;i&gt;[YAML]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;24 metric definitions +&lt;br&gt;business rules + master index&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EDE7F6;strokeColor=#7E57C2;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="560" y="420" width="150" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 5: MCP Server -->
+
+        <mxCell id="c-mcp" value="&lt;b&gt;MCP Server&lt;/b&gt;&lt;br&gt;&lt;i&gt;[FastMCP]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;17 tools — primary AI&lt;br&gt;data access layer&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#388E3C;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="560" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 5: FastAPI REST Server -->
+
+        <mxCell id="c-fastapi" value="&lt;b&gt;FastAPI REST Server&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;5 endpoints, Bearer auth, Tailscale&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="270" y="560" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 6: Desktop App -->
+
+        <mxCell id="c-desktop" value="&lt;b&gt;Desktop App&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Reports, UI&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="30" y="680" width="150" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Row 6: Export -->
+
+        <mxCell id="c-export" value="&lt;b&gt;Export&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;FHIR, PDF&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-local">
+          <mxGeometry x="220" y="680" width="150" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- CLOUD STACK BOUNDARY (right, gold dashed)     -->
+        <!-- ============================================= -->
+
+        <mxCell id="boundary-cloud" value="&lt;b&gt;Cloud Stack (Databricks)&lt;/b&gt;" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#FFF2CC;strokeColor=#D29922;verticalAlign=top;fontStyle=1;fontSize=14;fontFamily=Helvetica;container=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="820" y="160" width="400" height="530" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: Autoloader -->
+
+        <mxCell id="cloud-autoloader" value="&lt;b&gt;Autoloader&lt;/b&gt;&lt;br&gt;&lt;i&gt;[PySpark]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Ingests Parquet into Bronze Delta&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="30" y="50" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: Silver Runner -->
+
+        <mxCell id="cloud-silver" value="&lt;b&gt;Silver Runner&lt;/b&gt;&lt;br&gt;&lt;i&gt;[SQL]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;10 SQL transforms via DAB&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="30" y="160" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: Gold Runner -->
+
+        <mxCell id="cloud-gold" value="&lt;b&gt;Gold Runner&lt;/b&gt;&lt;br&gt;&lt;i&gt;[SQL]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;3 reporting views&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="30" y="270" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: Unity Catalog (cylinder) -->
+
+        <mxCell id="cloud-unity" value="&lt;b&gt;Unity Catalog&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;health-platform-dev / prd&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="260" y="140" width="120" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: Scheduled Workflows -->
+
+        <mxCell id="cloud-workflows" value="&lt;b&gt;Scheduled Workflows&lt;/b&gt;&lt;br&gt;&lt;i&gt;[DAB]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Bronze, Silver, Gold jobs&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="30" y="380" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud: GitHub Actions CI/CD -->
+
+        <mxCell id="cloud-gha" value="&lt;b&gt;GitHub Actions CI/CD&lt;/b&gt;&lt;br&gt;&lt;i&gt;[YAML]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Bundle validation, auto-deploy&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary-cloud">
+          <mxGeometry x="250" y="380" width="130" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- EDGES — Actor to Container                    -->
+        <!-- ============================================= -->
+
+        <!-- Claus → FastAPI REST Server -->
+        <mxCell id="edge-claus-fastapi" value="Manages via REST" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="person-claus" target="c-fastapi" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code → MCP Server -->
+        <mxCell id="edge-claude-mcp" value="Queries via MCP tools" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="person-claude" target="c-mcp" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code → FastAPI -->
+        <mxCell id="edge-claude-fastapi" value="Queries via REST API" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="person-claude" target="c-fastapi" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- EDGES — External Sources to Connectors        -->
+        <!-- ============================================= -->
+
+        <!-- Oura → Source Connectors -->
+        <mxCell id="edge-oura-conn" value="OAuth" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="ext-oura" target="c-source-connectors" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Apple Health → Source Connectors -->
+        <mxCell id="edge-apple-conn" value="XML" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="ext-apple" target="c-source-connectors" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Lifesum → Source Connectors -->
+        <mxCell id="edge-lifesum-conn" value="CSV" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="ext-lifesum" target="c-source-connectors" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- EDGES — Local Data Flow                       -->
+        <!-- ============================================= -->
+
+        <!-- Source Connectors → Parquet Data Lake -->
+        <mxCell id="edge-conn-parquet" value="Writes Parquet" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-source-connectors" target="c-parquet" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Parquet → Ingestion Engine -->
+        <mxCell id="edge-parquet-ingestion" value="Reads Parquet" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-parquet" target="c-ingestion" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Ingestion Engine → DuckDB -->
+        <mxCell id="edge-ingestion-duckdb" value="Loads Bronze" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-ingestion" target="c-duckdb" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- DuckDB ↔ dbt + Merge (bidirectional shown as two arrows) -->
+        <mxCell id="edge-duckdb-dbt" value="Bronze → Silver" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-duckdb" target="c-dbt" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge-dbt-duckdb" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-dbt" target="c-duckdb" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="590" y="400"/>
+              <mxPoint x="340" y="400"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- DuckDB → AI Modules -->
+        <mxCell id="edge-duckdb-ai" value="Reads Silver data" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-duckdb" target="c-ai-modules" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- AI Modules → Agent Memory (via DuckDB) -->
+        <mxCell id="edge-ai-memory" value="Writes Agent Memory" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-ai-modules" target="c-agent-memory" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Semantic Contracts → MCP Server -->
+        <mxCell id="edge-semantic-mcp" value="Defines query semantics" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-semantic" target="c-mcp" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- DuckDB → MCP Server -->
+        <mxCell id="edge-duckdb-mcp" value="Executes queries" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-duckdb" target="c-mcp" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="290" y="500"/>
+              <mxPoint x="170" y="500"/>
+              <mxPoint x="170" y="720"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Agent Memory → MCP Server -->
+        <mxCell id="edge-memory-mcp" value="Provides memory context" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-agent-memory" target="c-mcp" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- EDGES — Daily Sync orchestration (dashed)     -->
+        <!-- ============================================= -->
+
+        <!-- Daily Sync → Source Connectors -->
+        <mxCell id="edge-sync-conn" value="Triggers" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="c-daily-sync" target="c-source-connectors" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="500" y="250"/>
+              <mxPoint x="500" y="50"/>
+              <mxPoint x="280" y="50"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Daily Sync → Ingestion Engine -->
+        <mxCell id="edge-sync-ingestion" value="Triggers" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="c-daily-sync" target="c-ingestion" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Daily Sync → dbt + Merge Runner -->
+        <mxCell id="edge-sync-dbt" value="Triggers" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="c-daily-sync" target="c-dbt" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Daily Sync → AI Modules -->
+        <mxCell id="edge-sync-ai" value="Triggers" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="c-daily-sync" target="c-ai-modules" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="700" y="580"/>
+              <mxPoint x="700" y="630"/>
+              <mxPoint x="195" y="630"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ============================================= -->
+        <!-- EDGES — Cloud Data Flow                       -->
+        <!-- ============================================= -->
+
+        <!-- Parquet → Autoloader (cloud copy) -->
+        <mxCell id="edge-parquet-cloud" value="Cloud copy" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="c-parquet" target="cloud-autoloader" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="780" y="380"/>
+              <mxPoint x="780" y="250"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Autoloader → Unity Catalog -->
+        <mxCell id="edge-autoloader-unity" value="Writes Bronze Delta" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-autoloader" target="cloud-unity" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Unity Catalog ↔ Silver Runner -->
+        <mxCell id="edge-unity-silver" value="Bronze → Silver" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-unity" target="cloud-silver" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge-silver-unity" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-silver" target="cloud-unity" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="240" y="360"/>
+              <mxPoint x="310" y="360"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Unity Catalog ↔ Gold Runner -->
+        <mxCell id="edge-unity-gold" value="Silver → Gold" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-unity" target="cloud-gold" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge-gold-unity" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-gold" target="cloud-unity" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="240" y="370"/>
+              <mxPoint x="310" y="370"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Scheduled Workflows → Autoloader/Silver/Gold (dashed) -->
+        <mxCell id="edge-wf-autoloader" value="Orchestrates" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="cloud-workflows" target="cloud-autoloader" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="130" y="370"/>
+              <mxPoint x="130" y="130"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <mxCell id="edge-wf-silver" value="Orchestrates" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="cloud-workflows" target="cloud-silver" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge-wf-gold" value="Orchestrates" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;dashed=1;" edge="1" source="cloud-workflows" target="cloud-gold" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- GitHub Actions → Scheduled Workflows -->
+        <mxCell id="edge-gha-wf" value="Deploys DAB bundles" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="cloud-gha" target="cloud-workflows" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/c4-level3-components.drawio
+++ b/docs/c4-level3-components.drawio
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-03-11">
+  <diagram id="c4-level3" name="C4 Level 3 — Component Diagram">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1800" pageHeight="1400" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ===== ACTOR: Claude Code ===== -->
+        <mxCell id="actor_claude" value="&lt;b&gt;Claude Code&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;AI agent&lt;/font&gt;" style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="800" y="20" width="100" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- ===== BOUNDARY 1: MCP Server (FastMCP) ===== -->
+        <mxCell id="boundary_mcp" value="MCP Server (FastMCP)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#E8F5E9;strokeColor=#388E3C;verticalAlign=top;fontStyle=1;fontSize=13;fontFamily=Helvetica;container=1;collapsible=0;opacity=30;" vertex="1" parent="1">
+          <mxGeometry x="100" y="180" width="1500" height="180" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_server" value="&lt;b&gt;server.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[FastMCP]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Server entrypoint — registers 17 tools&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_mcp">
+          <mxGeometry x="30" y="40" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_health_tools" value="&lt;b&gt;health_tools.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Tool implementations — query routing, memory ops, insight recording&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_mcp">
+          <mxGeometry x="310" y="40" width="280" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_query_builder" value="&lt;b&gt;query_builder.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;YAML contract → parameterized SQL generation&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_mcp">
+          <mxGeometry x="650" y="40" width="260" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_formatter" value="&lt;b&gt;formatter.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Query results → markdown output formatting&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_mcp">
+          <mxGeometry x="970" y="40" width="240" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_schema_pruner" value="&lt;b&gt;schema_pruner.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Category-based schema pruning — only relevant tables in context&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_mcp">
+          <mxGeometry x="1270" y="40" width="200" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ===== BOUNDARY 2: AI Modules ===== -->
+        <mxCell id="boundary_ai" value="AI Modules" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#E8F5E9;strokeColor=#388E3C;verticalAlign=top;fontStyle=1;fontSize=13;fontFamily=Helvetica;container=1;collapsible=0;opacity=30;" vertex="1" parent="1">
+          <mxGeometry x="100" y="420" width="700" height="380" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_text_gen" value="&lt;b&gt;text_generator.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Template-based daily health narrative generation&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="30" y="40" width="290" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_embedding" value="&lt;b&gt;embedding_engine.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;sentence-transformers (all-MiniLM-L6-v2) — 384-dim embeddings + vector search&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="370" y="40" width="300" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_baseline" value="&lt;b&gt;baseline_computer.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Rolling baselines + demographics → patient_profile entries&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="30" y="130" width="290" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_correlation" value="&lt;b&gt;correlation_engine.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Pearson correlations with lag detection → metric_relationships&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="370" y="130" width="300" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_anomaly" value="&lt;b&gt;anomaly_detector.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Statistical anomaly detection across health metrics&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="30" y="220" width="290" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_recommendation" value="&lt;b&gt;recommendation_engine.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Evidence-based health recommendations with confidence scores&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="370" y="220" width="300" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_trend" value="&lt;b&gt;trend_forecaster.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Time-series forecasting for health metrics&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="30" y="300" width="290" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_notification" value="&lt;b&gt;notification_manager.py&lt;/b&gt;&lt;br&gt;&lt;i&gt;[Python]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Smart notification routing and prioritization&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_ai">
+          <mxGeometry x="370" y="300" width="300" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ===== BOUNDARY 3: Semantic Contracts (YAML) ===== -->
+        <mxCell id="boundary_contracts" value="Semantic Contracts (YAML)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#EDE7F6;strokeColor=#7E57C2;verticalAlign=top;fontStyle=1;fontSize=13;fontFamily=Helvetica;container=1;collapsible=0;opacity=30;" vertex="1" parent="1">
+          <mxGeometry x="860" y="420" width="740" height="280" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_index_yml" value="&lt;b&gt;_index.yml&lt;/b&gt;&lt;br&gt;&lt;i&gt;[YAML]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Master index — 9 categories, query routing config, schema pruning rules&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_contracts">
+          <mxGeometry x="30" y="50" width="310" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_business_rules" value="&lt;b&gt;_business_rules.yml&lt;/b&gt;&lt;br&gt;&lt;i&gt;[YAML]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Composite health score (35/35/30 weighting), 5 alert thresholds, anomaly detection&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_contracts">
+          <mxGeometry x="390" y="50" width="320" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="comp_metric_yamls" value="&lt;b&gt;24 metric YAMLs&lt;/b&gt;&lt;br&gt;&lt;i&gt;[YAML]&lt;/i&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Per-metric: computation SQL, thresholds, baselines, related metrics, example queries&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=11;fontFamily=Helvetica;verticalAlign=top;fontStyle=0;spacingTop=5;" vertex="1" parent="boundary_contracts">
+          <mxGeometry x="170" y="160" width="380" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ===== BOUNDARY 4: Agent Memory (DuckDB agent schema) ===== -->
+        <mxCell id="boundary_memory" value="Agent Memory (DuckDB agent schema)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#E1F0FF;strokeColor=#1E3A5F;verticalAlign=top;fontStyle=1;fontSize=13;fontFamily=Helvetica;container=1;collapsible=0;opacity=30;" vertex="1" parent="1">
+          <mxGeometry x="100" y="860" width="1500" height="180" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="db_patient_profile" value="&lt;b&gt;patient_profile&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Core memory — demographics + baselines, always in context (~2000 tokens)&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary_memory">
+          <mxGeometry x="40" y="50" width="280" height="100" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="db_daily_summaries" value="&lt;b&gt;daily_summaries&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Recall memory — one row per day + 384-dim embeddings for vector search&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary_memory">
+          <mxGeometry x="400" y="50" width="300" height="100" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="db_health_graph" value="&lt;b&gt;health_graph + edges&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Relationship memory — 67 nodes, 108 edges — semantic knowledge graph&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary_memory">
+          <mxGeometry x="780" y="50" width="310" height="100" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="db_knowledge_base" value="&lt;b&gt;knowledge_base&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Archival memory — accumulated insights, vector-searchable, grows over time&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="boundary_memory">
+          <mxGeometry x="1170" y="50" width="280" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- ===== ARROWS ===== -->
+
+        <!-- Claude Code → server.py: MCP protocol -->
+        <mxCell id="edge_claude_server" value="MCP protocol" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="actor_claude" target="comp_server" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- server.py → health_tools.py: Dispatches tool calls -->
+        <mxCell id="edge_server_tools" value="Dispatches tool calls" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_server" target="comp_health_tools" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → query_builder.py: Builds SQL from YAML contracts -->
+        <mxCell id="edge_tools_qb" value="Builds SQL from YAML contracts" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="comp_query_builder" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → formatter.py: Formats results -->
+        <mxCell id="edge_tools_fmt" value="Formats results" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="comp_formatter" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → schema_pruner.py: Selects relevant schema subset -->
+        <mxCell id="edge_tools_pruner" value="Selects relevant schema subset" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="comp_schema_pruner" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- query_builder.py → _index.yml: Reads routing config -->
+        <mxCell id="edge_qb_index" value="Reads routing config" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_query_builder" target="comp_index_yml" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- query_builder.py → 24 metric YAMLs: Reads computation SQL -->
+        <mxCell id="edge_qb_metrics" value="Reads computation SQL" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_query_builder" target="comp_metric_yamls" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- schema_pruner.py → _index.yml: Reads pruning rules -->
+        <mxCell id="edge_pruner_index" value="Reads pruning rules" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_schema_pruner" target="comp_index_yml" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → patient_profile: get_profile — loads core memory -->
+        <mxCell id="edge_tools_profile" value="get_profile — loads core memory" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="db_patient_profile" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → daily_summaries: search_memory — vector search -->
+        <mxCell id="edge_tools_daily" value="search_memory — vector search" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="db_daily_summaries" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → health_graph: discover_correlations — traverses graph -->
+        <mxCell id="edge_tools_graph" value="discover_correlations — traverses graph" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="db_health_graph" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- health_tools.py → knowledge_base: record_insight / search_memory -->
+        <mxCell id="edge_tools_kb" value="record_insight / search_memory" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_health_tools" target="db_knowledge_base" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- text_generator.py → daily_summaries: Generates daily narratives -->
+        <mxCell id="edge_textgen_daily" value="Generates daily narratives" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_text_gen" target="db_daily_summaries" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- embedding_engine.py → daily_summaries: Computes and stores embeddings -->
+        <mxCell id="edge_embed_daily" value="Computes and stores embeddings" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_embedding" target="db_daily_summaries" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- baseline_computer.py → patient_profile: Computes and updates baselines -->
+        <mxCell id="edge_baseline_profile" value="Computes and updates baselines" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_baseline" target="db_patient_profile" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- correlation_engine.py → health_graph: Writes correlation edges -->
+        <mxCell id="edge_corr_graph" value="Writes correlation edges" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_correlation" target="db_health_graph" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- anomaly_detector.py → daily_summaries: Reads metrics for anomaly detection -->
+        <mxCell id="edge_anomaly_daily" value="Reads metrics for anomaly detection" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_anomaly" target="db_daily_summaries" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- recommendation_engine.py → knowledge_base: Reads/writes recommendations -->
+        <mxCell id="edge_rec_kb" value="Reads/writes recommendations" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_recommendation" target="db_knowledge_base" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- trend_forecaster.py → daily_summaries: Reads historical data for forecasting -->
+        <mxCell id="edge_trend_daily" value="Reads historical data for forecasting" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_trend" target="db_daily_summaries" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- notification_manager.py → patient_profile: Reads notification preferences -->
+        <mxCell id="edge_notif_profile" value="Reads notification preferences" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_notification" target="db_patient_profile" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- _business_rules.yml → health_tools.py: Defines alert logic and scoring -->
+        <mxCell id="edge_rules_tools" value="Defines alert logic and scoring" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#666666;strokeWidth=1;fontSize=9;fontFamily=Helvetica;" edge="1" source="comp_business_rules" target="comp_health_tools" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/solution-architecture.drawio
+++ b/docs/solution-architecture.drawio
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-03-11T00:00:00.000Z" agent="Claude" version="24.0.0" type="device">
+  <diagram id="solution-arch" name="Solution Architecture">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ======================== -->
+        <!-- BOUNDARY BOXES           -->
+        <!-- ======================== -->
+
+        <!-- Local Stack boundary -->
+        <mxCell id="2" value="Local Stack (Mac Mini M4)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#DCEEFB;strokeColor=#1F6FEB;verticalAlign=top;fontStyle=1;fontSize=14;fontFamily=Helvetica;opacity=40;" vertex="1" parent="1">
+          <mxGeometry x="200" y="100" width="1000" height="750" as="geometry"/>
+        </mxCell>
+
+        <!-- Cloud Stack boundary -->
+        <mxCell id="3" value="Cloud Stack (Databricks)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=5 5;fillColor=#FFF2CC;strokeColor=#D29922;verticalAlign=top;fontStyle=1;fontSize=14;fontFamily=Helvetica;opacity=40;" vertex="1" parent="1">
+          <mxGeometry x="1240" y="100" width="330" height="460" as="geometry"/>
+        </mxCell>
+
+        <!-- Daily Sync boundary -->
+        <mxCell id="4" value="Daily Sync (launchd 06:00)" style="rounded=1;whiteSpace=wrap;html=1;dashed=1;dashPattern=3 3;fillColor=none;strokeColor=#999999;verticalAlign=top;fontStyle=2;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="210" y="200" width="980" height="340" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- PERSON SHAPES            -->
+        <!-- ======================== -->
+
+        <!-- Claus (top-left) -->
+        <mxCell id="5" value="Claus" style="shape=mxgraph.basic.person;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="110" width="60" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Claude Code (right side) -->
+        <mxCell id="6" value="Claude Code" style="shape=mxgraph.basic.person;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1360" y="640" width="60" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- EXTERNAL SOURCES (left)  -->
+        <!-- ======================== -->
+
+        <mxCell id="10" value="Oura&lt;br&gt;(OAuth)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="220" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="Apple Health&lt;br&gt;(XML)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="260" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="Lifesum&lt;br&gt;(CSV)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="300" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="Withings&lt;br&gt;(OAuth)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="340" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" value="Strava&lt;br&gt;(OAuth)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="380" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" value="sundhed.dk&lt;br&gt;(Playwright)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="420" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" value="Weather API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="460" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" value="Genetics&lt;br&gt;(CSV)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="500" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" value="Lab Results&lt;br&gt;(CSV)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="20" y="540" width="90" height="35" as="geometry"/>
+        </mxCell>
+
+        <!-- Sources group label -->
+        <mxCell id="19" value="External APIs / Files" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="10" y="193" width="130" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- SOURCE CONNECTORS        -->
+        <!-- ======================== -->
+
+        <mxCell id="20" value="Source Connectors&lt;br&gt;(9 Python modules)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="220" y="350" width="150" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- PARQUET DATA LAKE         -->
+        <!-- ======================== -->
+
+        <mxCell id="21" value="Parquet Data Lake&lt;br&gt;(Hive-partitioned)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="420" y="225" width="140" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- INGESTION ENGINE          -->
+        <!-- ======================== -->
+
+        <mxCell id="22" value="Ingestion Engine&lt;br&gt;(YAML-driven)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="420" y="345" width="140" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- BRONZE                    -->
+        <!-- ======================== -->
+
+        <mxCell id="23" value="Bronze&lt;br&gt;(DuckDB, stg_*)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="620" y="225" width="130" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- dbt + Merge Runner        -->
+        <!-- ======================== -->
+
+        <mxCell id="24" value="dbt + Merge Runner&lt;br&gt;(Bronze → Silver)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="610" y="345" width="150" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- SILVER                    -->
+        <!-- ======================== -->
+
+        <mxCell id="25" value="Silver&lt;br&gt;(21 tables, COMMENT ON)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="830" y="330" width="150" height="75" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- LOCAL AI PATH             -->
+        <!-- ======================== -->
+
+        <!-- AI Modules -->
+        <mxCell id="30" value="AI Modules&lt;br&gt;(8 modules)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#388E3C;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="610" y="570" width="140" height="55" as="geometry"/>
+        </mxCell>
+
+        <!-- AI Modules detail tooltip -->
+        <mxCell id="31" value="text_generator, embedding_engine,&lt;br&gt;baseline_computer, correlation_engine,&lt;br&gt;anomaly_detector, recommendation_engine,&lt;br&gt;trend_forecaster, notification_manager" style="text;html=1;align=left;verticalAlign=top;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=8;fontFamily=Helvetica;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="580" y="630" width="200" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- Agent Memory -->
+        <mxCell id="32" value="Agent Memory&lt;br&gt;(DuckDB agent schema)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="810" y="565" width="160" height="65" as="geometry"/>
+        </mxCell>
+
+        <!-- Agent Memory detail -->
+        <mxCell id="33" value="patient_profile, daily_summaries,&lt;br&gt;health_graph, knowledge_base" style="text;html=1;align=left;verticalAlign=top;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=8;fontFamily=Helvetica;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="810" y="635" width="170" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Semantic Contracts -->
+        <mxCell id="34" value="Semantic Contracts&lt;br&gt;(24 YAML metrics)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EDE7F6;strokeColor=#7E57C2;fontSize=11;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="810" y="700" width="160" height="55" as="geometry"/>
+        </mxCell>
+
+        <!-- MCP Server -->
+        <mxCell id="35" value="MCP Server&lt;br&gt;(FastMCP, 17 tools)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#388E3C;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1050" y="640" width="160" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- CLOUD PATH                -->
+        <!-- ======================== -->
+
+        <!-- Autoloader -->
+        <mxCell id="40" value="Autoloader&lt;br&gt;(PySpark)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="210" width="140" height="55" as="geometry"/>
+        </mxCell>
+
+        <!-- Silver/Gold Delta -->
+        <mxCell id="41" value="Silver / Gold Delta&lt;br&gt;(Unity Catalog)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=15;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=12;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="320" width="150" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- Databricks Dashboards -->
+        <mxCell id="42" value="Databricks&lt;br&gt;Dashboards" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1290" y="440" width="130" height="55" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- EDGES (ARROWS)            -->
+        <!-- ======================== -->
+
+        <!-- Sources → Source Connectors (bundle) -->
+        <mxCell id="100" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" edge="1" source="10" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="101" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="12" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="102" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="13" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="103" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="14" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="104" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" edge="1" source="15" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="105" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" edge="1" source="16" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="106" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" source="17" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="107" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" source="18" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="108" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" edge="1" source="11" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Source Connectors → Parquet Data Lake -->
+        <mxCell id="110" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" edge="1" source="20" target="21" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Source Connectors → Ingestion Engine -->
+        <mxCell id="111" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="20" target="22" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Ingestion Engine → Bronze -->
+        <mxCell id="112" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" source="22" target="23" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Bronze → dbt + Merge Runner -->
+        <mxCell id="113" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="23" target="24" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- dbt + Merge Runner → Silver -->
+        <mxCell id="114" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" source="24" target="25" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Silver → AI Modules (local AI path, downward) -->
+        <mxCell id="120" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="25" target="30" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="905" y="470"/>
+              <mxPoint x="680" y="470"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- AI Modules → Agent Memory -->
+        <mxCell id="121" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" source="30" target="32" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Agent Memory → Semantic Contracts -->
+        <mxCell id="122" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="32" target="34" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Semantic Contracts → MCP Server -->
+        <mxCell id="123" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="34" target="35" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- MCP Server → Claude Code -->
+        <mxCell id="124" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="35" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Silver → Autoloader (cloud path, rightward) -->
+        <mxCell id="130" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=1;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="25" target="40" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1230" y="368"/>
+              <mxPoint x="1230" y="238"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Autoloader → Silver/Gold Delta -->
+        <mxCell id="131" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" source="40" target="41" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Silver/Gold Delta → Databricks Dashboards -->
+        <mxCell id="132" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#333333;strokeWidth=1.5;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="41" target="42" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Claus → Sources (dashed, indicating ownership) -->
+        <mxCell id="140" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#9673A6;strokeWidth=1;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" source="5" target="19" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Claus → Databricks Dashboards (dashed, views) -->
+        <mxCell id="141" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#9673A6;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="5" target="42" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="130" y="145"/>
+              <mxPoint x="130" y="130"/>
+              <mxPoint x="1355" y="130"/>
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- NUMBERED FLOW CIRCLES     -->
+        <!-- ======================== -->
+
+        <!-- 1: External APIs/Files -->
+        <mxCell id="200" value="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="120" y="365" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 2: Source Connectors -->
+        <mxCell id="201" value="2" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="260" y="320" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 3: Parquet Data Lake -->
+        <mxCell id="202" value="3" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="390" y="240" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 4: Ingestion Engine -->
+        <mxCell id="203" value="4" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="380" y="360" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 5: Bronze -->
+        <mxCell id="204" value="5" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="590" y="240" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 6: dbt + Merge Runner -->
+        <mxCell id="205" value="6" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="670" y="310" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 7: Silver -->
+        <mxCell id="206" value="7" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="790" y="350" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 8: AI Modules -->
+        <mxCell id="207" value="8" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="620" y="480" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 9: Agent Memory -->
+        <mxCell id="208" value="9" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="775" y="575" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 10: Semantic Contracts -->
+        <mxCell id="209" value="10" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="875" y="670" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 11: MCP Server -->
+        <mxCell id="210" value="11" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1020" y="650" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 12: Autoloader -->
+        <mxCell id="211" value="12" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1250" y="220" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 13: Silver/Gold Delta -->
+        <mxCell id="212" value="13" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1345" y="290" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- 14: Databricks Dashboards -->
+        <mxCell id="213" value="14" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;fontColor=#FFFFFF;fontSize=14;fontStyle=1;aspect=fixed;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1345" y="410" width="30" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- LEGEND (bottom-right)     -->
+        <!-- ======================== -->
+
+        <mxCell id="300" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F5F5F5;strokeColor=#CCCCCC;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1260" y="600" width="310" height="250" as="geometry"/>
+        </mxCell>
+        <mxCell id="301" value="Legend" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=12;fontFamily=Helvetica;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1270" y="605" width="60" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: External Source -->
+        <mxCell id="302" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82B366;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="635" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="303" value="External Source" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="628" width="100" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Internal Component -->
+        <mxCell id="304" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="657" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="305" value="Internal Component" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="650" width="120" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Database -->
+        <mxCell id="306" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#EF6C00;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="679" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="307" value="Database / Storage" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="672" width="120" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: MCP/AI Layer -->
+        <mxCell id="308" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#388E3C;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="701" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="309" value="MCP / AI Layer" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="694" width="100" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Semantic Contracts -->
+        <mxCell id="310" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EDE7F6;strokeColor=#7E57C2;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="723" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="311" value="Semantic Contracts" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="716" width="120" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Agent Memory -->
+        <mxCell id="312" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F0FF;strokeColor=#1E3A5F;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="745" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="313" value="Agent Memory" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="738" width="90" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Numbered circle -->
+        <mxCell id="314" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#1F6FEB;strokeColor=#1F6FEB;aspect=fixed;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="767" width="18" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="315" value="Flow Step (numbered)" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="760" width="130" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Person -->
+        <mxCell id="316" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1D5E7;strokeColor=#9673A6;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="789" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="317" value="Person / Actor" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="782" width="90" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Legend: Dashed = boundary -->
+        <mxCell id="318" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#999999;dashed=1;dashPattern=5 5;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1275" y="811" width="20" height="14" as="geometry"/>
+        </mxCell>
+        <mxCell id="319" value="Boundary / Orchestration" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=10;fontFamily=Helvetica;" vertex="1" parent="1">
+          <mxGeometry x="1300" y="804" width="150" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======================== -->
+        <!-- TITLE                     -->
+        <!-- ======================== -->
+
+        <mxCell id="400" value="HealthReporting — Solution Architecture" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=18;fontFamily=Helvetica;fontStyle=1;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="420" y="50" width="370" height="40" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="401" value="Dual-stack: Local Mac Mini M4 + Cloud Databricks | 14-step numbered flow" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=11;fontFamily=Helvetica;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="420" y="80" width="380" height="30" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- Add 4 editable draw.io files: C4 Level 1 (Context), Level 2 (Containers), Level 3 (Components), and Solution Architecture (14-step numbered flow)
- Fix outdated counts in c4-architecture.md (8→17 MCP tools, 4→8 AI modules)
- Remove old HTML diagram files (architecture-diagram.html, c4-diagram.html)
- Document draw.io as standard tool for architecture diagrams

## Test plan
- [x] All 4 .drawio files pass xmllint validation
- [x] Content matches codebase: 17 MCP tools, 8 AI modules, 9 connectors, 24 contracts
- [ ] Visual check in draw.io desktop app

Generated with Claude Code