### PR TITLE
feat(ingestion): bronze incremental delta load with watermarks

### DIFF
--- a/health_unified_platform/health_platform/transformation_logic/ingestion_engine.py
+++ b/health_unified_platform/health_platform/transformation_logic/ingestion_engine.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -8,6 +9,8 @@ import yaml
 from health_platform.utils.audit_logger import AuditLogger
 from health_platform.utils.logging_config import get_logger
 from health_platform.utils.path_resolver import get_project_root
+
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 logger = get_logger("ingestion_engine")
 
@@ -65,7 +68,10 @@ def _filter_new_files(
     new_files = []
     max_mtime = watermark
     for f in files:
-        mtime = datetime.fromtimestamp(os.path.getmtime(f), tz=timezone.utc)
+        try:
+            mtime = datetime.fromtimestamp(os.path.getmtime(f), tz=timezone.utc)
+        except OSError:
+            continue
         if mtime > watermark:
             new_files.append(f)
             if mtime > max_mtime:
@@ -110,6 +116,17 @@ def run_ingestion():
             input_glob = str(lake_root / source["relative_path"])
 
             logger.info(f"Processing source: {name} -> {schema}.{table}")
+
+            # validate identifiers before f-string SQL interpolation
+            if not _IDENTIFIER_RE.match(schema) or not _IDENTIFIER_RE.match(table):
+                logger.error(f"Invalid identifier in source {name}: {schema}.{table}")
+                continue
+
+            # containment check: relative_path must resolve inside data lake
+            resolved_glob = Path(input_glob).resolve()
+            if not str(resolved_glob).startswith(str(lake_root.resolve())):
+                logger.error(f"Path escape detected for {name}: {input_glob}")
+                continue
 
             # verify_file_existence
             found_files = glob.glob(input_glob, recursive=True)


### PR DESCRIPTION
## Summary
- Replace full-load CREATE OR REPLACE with file-mtime watermark tracking in `ingestion_engine.py`
- Cold start creates tables on first run; subsequent runs only INSERT files newer than last watermark
- Uses DuckDB `columns()` lambda to handle mixed parquet schemas (HAE vs XML-origin)
- Security hardening: TOCTOU guard, path containment check, identifier validation

## Key changes
- `bronze._load_watermarks` table tracks per-source last_loaded_at, files_loaded, rows_loaded
- `INSERT INTO ... BY NAME` for schema-evolution-safe incremental loads
- `columns(c -> c NOT IN ('_ingested_at', '_source_env'))` strips duplicate metadata columns
- Regex identifier validation + path escape detection before f-string SQL

## Test plan
- [x] Clean cold start: 67 sources loaded successfully
- [x] Delta verification: second run = "0 loaded, 67 skipped (no new data)"
- [x] Silver merges: 34/59 succeeded (25 failures are pre-existing — missing data or SQL bugs)
- [x] Security review: all findings addressed (TOCTOU, path containment, identifier validation)
- [ ] 4 pre-existing errors unchanged: withings hive partition mismatch, manual YAML files

Generated with Claude Code