### PR TITLE
fix(ai): remove 100-char truncation from reflection and focus text

### DIFF
--- a/health_unified_platform/health_platform/ai/text_generator.py
+++ b/health_unified_platform/health_platform/ai/text_generator.py
@@ -193,14 +193,14 @@ def generate_daily_summary(con, day: date) -> str:
     if focus:
         text = focus.get("focus_text") or ""
         if text:
-            parts.append(f"Focus: {text[:100]}.")
+            parts.append(f"Focus: {text}.")
 
     # --- Reflections (daily-stoic) ---
     reflection = _query_row(con, "silver.daily_stoic_reflections", "day", day)
     if reflection:
         text = reflection.get("reflection_text") or ""
         if text:
-            parts.append(f"Reflection: {text[:100]}.")
+            parts.append(f"Reflection: {text}.")
 
     # --- Habits (daily-stoic) ---
     habits = _query_habits_summary(con, day)

--- a/tests/test_text_generator.py
+++ b/tests/test_text_generator.py
@@ -296,22 +296,19 @@ class TestDailyStoicSectionsInSummary:
         assert "Memento mori" in summary
         con.close()
 
-    def test_focus_text_truncated_at_100_chars(self):
-        """Focus text longer than 100 characters is truncated in the summary."""
+    def test_focus_text_included_in_full(self):
+        """Focus text is included in full without truncation."""
         from datetime import date
 
         from health_platform.ai.text_generator import generate_daily_summary
 
         con = self._base_db()
-        # Use two distinct halves so truncation is unambiguous
         long_text = "X" * 100 + "Z" * 50
         con.execute(
             f"INSERT INTO silver.daily_stoic_focus VALUES ('2026-03-01', '{long_text}')"
         )
         summary = generate_daily_summary(con, date(2026, 3, 1))
-        # First 100 chars (all X) must be present; the Z suffix must be absent
-        assert "X" * 100 in summary
-        assert "Z" not in summary
+        assert long_text in summary
         con.close()
 
     def test_no_focus_row_omits_focus_section(self):


### PR DESCRIPTION
## Summary
- Removes hard `text[:100]` truncation from `reflection_text` and `focus_text` in `text_generator.py`
- Daily summaries now include full text — data analysis shows max 213 chars, no embedding risk

## Test plan
- [ ] CI checks pass
- [ ] Verify daily summary generation includes full reflection text

Generated with Claude Code