### PR TITLE
refactor(silver): rename source_name → source_system across full silver layer

### DIFF
--- a/health_unified_platform/health_platform/setup/add_column_comments.sql
+++ b/health_unified_platform/health_platform/setup/add_column_comments.sql
@@ -43,7 +43,7 @@ COMMENT ON COLUMN silver.body_temperature.sk_date IS 'Surrogate date key in YYYY
 COMMENT ON COLUMN silver.body_temperature.sk_time IS 'Surrogate time key as HH:MM string.';
 COMMENT ON COLUMN silver.body_temperature.timestamp IS 'UTC timestamp of the temperature measurement.';
 COMMENT ON COLUMN silver.body_temperature.temperature_degc IS 'Body temperature in degrees Celsius. Normal core range: 36.1-37.2C. Skin temperature from wearables is typically 1-2C lower. Deviations can indicate illness, ovulation, or circadian phase.';
-COMMENT ON COLUMN silver.body_temperature.source_name IS 'Name of the device or app that produced the reading (e.g., Oura skin temp, manual thermometer).';
+COMMENT ON COLUMN silver.body_temperature.source_system IS 'Name of the device or app that produced the reading (e.g., Oura skin temp, manual thermometer).';
 COMMENT ON COLUMN silver.body_temperature.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.body_temperature.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.body_temperature.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -106,7 +106,7 @@ COMMENT ON TABLE silver.daily_energy_by_source IS 'Daily energy expenditure brok
 
 COMMENT ON COLUMN silver.daily_energy_by_source.sk_date IS 'Surrogate date key in YYYYMMDD integer format.';
 COMMENT ON COLUMN silver.daily_energy_by_source.date IS 'Calendar date for this energy summary.';
-COMMENT ON COLUMN silver.daily_energy_by_source.source_name IS 'Name of the source device or app reporting energy data (e.g., Apple Watch, Oura, Strava).';
+COMMENT ON COLUMN silver.daily_energy_by_source.source_system IS 'Name of the source device or app reporting energy data (e.g., Apple Watch, Oura, Strava).';
 COMMENT ON COLUMN silver.daily_energy_by_source.active_energy_kcal IS 'Active energy burned as reported by this source. Unit: kilocalories. Excludes basal metabolic rate.';
 COMMENT ON COLUMN silver.daily_energy_by_source.basal_energy_kcal IS 'Basal (resting) energy expenditure as estimated by this source. Unit: kilocalories.';
 COMMENT ON COLUMN silver.daily_energy_by_source.total_energy_kcal IS 'Total energy expenditure (active + basal) as reported by this source. Unit: kilocalories.';
@@ -247,7 +247,7 @@ COMMENT ON COLUMN silver.heart_rate.sk_date IS 'Surrogate date key in YYYYMMDD i
 COMMENT ON COLUMN silver.heart_rate.sk_time IS 'Surrogate time key as HH:MM string.';
 COMMENT ON COLUMN silver.heart_rate.timestamp IS 'UTC timestamp of the heart rate measurement.';
 COMMENT ON COLUMN silver.heart_rate.bpm IS 'Heart rate in beats per minute. Resting: 60-100 bpm (athletes: 40-60). Max HR ~220 minus age. Source: optical PPG sensor on wearable.';
-COMMENT ON COLUMN silver.heart_rate.source_name IS 'Name of the device that produced the reading (e.g., Oura, Apple Watch).';
+COMMENT ON COLUMN silver.heart_rate.source_system IS 'Name of the device that produced the reading (e.g., Oura, Apple Watch).';
 COMMENT ON COLUMN silver.heart_rate.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.heart_rate.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.heart_rate.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -263,7 +263,7 @@ COMMENT ON COLUMN silver.mindful_session.sk_time IS 'Surrogate time key as HH:MM
 COMMENT ON COLUMN silver.mindful_session.timestamp IS 'UTC timestamp when the mindfulness session started.';
 COMMENT ON COLUMN silver.mindful_session.end_timestamp IS 'UTC timestamp when the mindfulness session ended.';
 COMMENT ON COLUMN silver.mindful_session.duration_seconds IS 'Duration of the mindfulness session. Unit: seconds. Typical range: 300-1800 seconds (5-30 minutes). Research suggests 10+ minutes yields measurable HRV benefits.';
-COMMENT ON COLUMN silver.mindful_session.source_name IS 'Name of the app or device that recorded the session (e.g., Headspace, Apple Watch Mindfulness).';
+COMMENT ON COLUMN silver.mindful_session.source_system IS 'Name of the app or device that recorded the session (e.g., Headspace, Apple Watch Mindfulness).';
 COMMENT ON COLUMN silver.mindful_session.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.mindful_session.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.mindful_session.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -294,7 +294,7 @@ COMMENT ON COLUMN silver.respiratory_rate.sk_time IS 'Surrogate time key as HH:M
 COMMENT ON COLUMN silver.respiratory_rate.timestamp IS 'UTC timestamp when the respiratory rate measurement started.';
 COMMENT ON COLUMN silver.respiratory_rate.end_timestamp IS 'UTC timestamp when the respiratory rate measurement ended.';
 COMMENT ON COLUMN silver.respiratory_rate.breaths_per_min IS 'Respiratory rate. Unit: breaths per minute. Normal adult resting: 12-20 breaths/min. Elevated rates (>20) at rest may indicate stress, fever, or respiratory issues.';
-COMMENT ON COLUMN silver.respiratory_rate.source_name IS 'Name of the device that measured respiratory rate (e.g., Oura Ring, Apple Watch).';
+COMMENT ON COLUMN silver.respiratory_rate.source_system IS 'Name of the device that measured respiratory rate (e.g., Oura Ring, Apple Watch).';
 COMMENT ON COLUMN silver.respiratory_rate.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.respiratory_rate.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.respiratory_rate.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -311,7 +311,7 @@ COMMENT ON COLUMN silver.step_count.timestamp IS 'UTC timestamp for the start of
 COMMENT ON COLUMN silver.step_count.end_timestamp IS 'UTC timestamp for the end of the step counting interval.';
 COMMENT ON COLUMN silver.step_count.duration_seconds IS 'Duration of the step counting interval. Unit: seconds.';
 COMMENT ON COLUMN silver.step_count.step_count IS 'Number of steps recorded during the interval. Cadence (steps/min) can be derived: step_count / (duration_seconds / 60). Walking cadence ~100-130 steps/min, running ~150-190.';
-COMMENT ON COLUMN silver.step_count.source_name IS 'Name of the device that counted steps (e.g., iPhone, Apple Watch, Oura).';
+COMMENT ON COLUMN silver.step_count.source_system IS 'Name of the device that counted steps (e.g., iPhone, Apple Watch, Oura).';
 COMMENT ON COLUMN silver.step_count.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.step_count.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.step_count.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -327,7 +327,7 @@ COMMENT ON COLUMN silver.toothbrushing.sk_time IS 'Surrogate time key as HH:MM s
 COMMENT ON COLUMN silver.toothbrushing.timestamp IS 'UTC timestamp when the toothbrushing session started.';
 COMMENT ON COLUMN silver.toothbrushing.end_timestamp IS 'UTC timestamp when the toothbrushing session ended.';
 COMMENT ON COLUMN silver.toothbrushing.duration_seconds IS 'Duration of the brushing session. Unit: seconds. Dentist recommendation: 120 seconds (2 minutes) minimum.';
-COMMENT ON COLUMN silver.toothbrushing.source_name IS 'Name of the device or app that detected the brushing session.';
+COMMENT ON COLUMN silver.toothbrushing.source_system IS 'Name of the device or app that detected the brushing session.';
 COMMENT ON COLUMN silver.toothbrushing.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.toothbrushing.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.toothbrushing.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';
@@ -342,7 +342,7 @@ COMMENT ON COLUMN silver.water_intake.sk_date IS 'Surrogate date key in YYYYMMDD
 COMMENT ON COLUMN silver.water_intake.sk_time IS 'Surrogate time key as HH:MM string.';
 COMMENT ON COLUMN silver.water_intake.timestamp IS 'UTC timestamp when the water intake was logged.';
 COMMENT ON COLUMN silver.water_intake.water_ml IS 'Volume of water consumed. Unit: milliliters. Daily target varies by body weight; general guideline: 30-40 ml per kg body weight. Source: manual logging app.';
-COMMENT ON COLUMN silver.water_intake.source_name IS 'Name of the app used to log the water intake.';
+COMMENT ON COLUMN silver.water_intake.source_system IS 'Name of the app used to log the water intake.';
 COMMENT ON COLUMN silver.water_intake.business_key_hash IS 'MD5/SHA hash of the natural business key columns.';
 COMMENT ON COLUMN silver.water_intake.row_hash IS 'MD5/SHA hash of all non-key columns for change detection.';
 COMMENT ON COLUMN silver.water_intake.load_datetime IS 'Timestamp when this row was first loaded into the silver layer.';

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_audio_exposure.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_audio_exposure.sql
@@ -46,7 +46,7 @@ SELECT
     avg_db,
     max_db,
     sample_count,
-    'apple_health' AS source_name,
+    'apple_health' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' ||
         exposure_type
@@ -74,17 +74,17 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     avg_db            = src.avg_db,
     max_db            = src.max_db,
     sample_count      = src.sample_count,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, date, exposure_type, avg_db, max_db, sample_count, source_name,
+    sk_date, date, exposure_type, avg_db, max_db, sample_count, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.date, src.exposure_type, src.avg_db, src.max_db, src.sample_count, src.source_name,
+    src.sk_date, src.date, src.exposure_type, src.avg_db, src.max_db, src.sample_count, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_blood_pressure_v2.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_blood_pressure_v2.sql
@@ -31,7 +31,7 @@ SELECT
     ROUND(systolic_mmhg, 1) AS systolic_mmhg,
     ROUND(diastolic_mmhg, 1) AS diastolic_mmhg,
     NULL::DOUBLE AS pulse_bpm,
-    'apple_health' AS source_name,
+    'apple_health' AS source_system,
     md5(coalesce(cast(startDate AS VARCHAR), '') || '||' || 'apple_health') AS business_key_hash,
     md5(cast(startDate AS VARCHAR) || '||' || cast(systolic_mmhg AS VARCHAR) || '||' || cast(diastolic_mmhg AS VARCHAR)) AS row_hash,
     current_timestamp AS load_datetime
@@ -44,10 +44,10 @@ ON target.business_key_hash = src.business_key_hash
 WHEN MATCHED AND target.row_hash <> src.row_hash THEN
   UPDATE SET sk_date=src.sk_date, sk_time=src.sk_time, timestamp=src.timestamp,
     systolic_mmhg=src.systolic_mmhg, diastolic_mmhg=src.diastolic_mmhg, pulse_bpm=src.pulse_bpm,
-    source_name=src.source_name, row_hash=src.row_hash, update_datetime=current_timestamp
+    source_system=src.source_system, row_hash=src.row_hash, update_datetime=current_timestamp
 WHEN NOT MATCHED THEN
-  INSERT (sk_date, sk_time, timestamp, systolic_mmhg, diastolic_mmhg, pulse_bpm, source_name, business_key_hash, row_hash, load_datetime, update_datetime)
-  VALUES (src.sk_date, src.sk_time, src.timestamp, src.systolic_mmhg, src.diastolic_mmhg, src.pulse_bpm, src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp);
+  INSERT (sk_date, sk_time, timestamp, systolic_mmhg, diastolic_mmhg, pulse_bpm, source_system, business_key_hash, row_hash, load_datetime, update_datetime)
+  VALUES (src.sk_date, src.sk_time, src.timestamp, src.systolic_mmhg, src.diastolic_mmhg, src.pulse_bpm, src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp);
 
 -- Step 3: Drop staging table
 DROP TABLE IF EXISTS silver.blood_pressure_v2__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_body_measurement.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_body_measurement.sql
@@ -11,40 +11,40 @@
 -- Step 1: Aggregate each source to daily level, then wide JOIN
 CREATE OR REPLACE TABLE silver.body_measurement__staging AS
 WITH mass_daily AS (
-    SELECT startDate::DATE AS date, sourceName AS source_name, value::DOUBLE AS weight_kg,
+    SELECT startDate::DATE AS date, sourceName AS source_system, value::DOUBLE AS weight_kg,
            ROW_NUMBER() OVER (PARTITION BY startDate::DATE, sourceName ORDER BY _ingested_at DESC) AS rn
     FROM bronze.stg_apple_health_body_mass WHERE startDate IS NOT NULL AND value::DOUBLE > 0
 ),
 fat_daily AS (
-    SELECT startDate::DATE AS date, sourceName AS source_name, value::DOUBLE AS body_fat_pct,
+    SELECT startDate::DATE AS date, sourceName AS source_system, value::DOUBLE AS body_fat_pct,
            ROW_NUMBER() OVER (PARTITION BY startDate::DATE, sourceName ORDER BY _ingested_at DESC) AS rn
     FROM bronze.stg_apple_health_body_fat_percentage WHERE startDate IS NOT NULL AND value::DOUBLE > 0
 ),
 lean_daily AS (
-    SELECT startDate::DATE AS date, sourceName AS source_name, value::DOUBLE AS lean_body_mass_kg,
+    SELECT startDate::DATE AS date, sourceName AS source_system, value::DOUBLE AS lean_body_mass_kg,
            ROW_NUMBER() OVER (PARTITION BY startDate::DATE, sourceName ORDER BY _ingested_at DESC) AS rn
     FROM bronze.stg_apple_health_lean_body_mass WHERE startDate IS NOT NULL AND value::DOUBLE > 0
 ),
 bmi_daily AS (
-    SELECT startDate::DATE AS date, sourceName AS source_name, value::DOUBLE AS bmi,
+    SELECT startDate::DATE AS date, sourceName AS source_system, value::DOUBLE AS bmi,
            ROW_NUMBER() OVER (PARTITION BY startDate::DATE, sourceName ORDER BY _ingested_at DESC) AS rn
     FROM bronze.stg_apple_health_bmi WHERE startDate IS NOT NULL AND value::DOUBLE > 0
 ),
 height_daily AS (
-    SELECT startDate::DATE AS date, sourceName AS source_name, value::DOUBLE AS height_m,
+    SELECT startDate::DATE AS date, sourceName AS source_system, value::DOUBLE AS height_m,
            ROW_NUMBER() OVER (PARTITION BY startDate::DATE, sourceName ORDER BY _ingested_at DESC) AS rn
     FROM bronze.stg_apple_health_height WHERE startDate IS NOT NULL AND value::DOUBLE > 0
 ),
 combined AS (
     SELECT
         coalesce(m.date, f.date, l.date, b.date, h.date) AS date,
-        coalesce(m.source_name, f.source_name, l.source_name, b.source_name, h.source_name) AS source_name,
+        coalesce(m.source_system, f.source_system, l.source_system, b.source_system, h.source_system) AS source_system,
         m.weight_kg, f.body_fat_pct, l.lean_body_mass_kg, b.bmi, h.height_m
-    FROM (SELECT date, source_name, weight_kg FROM mass_daily WHERE rn = 1) m
-    FULL OUTER JOIN (SELECT date, source_name, body_fat_pct FROM fat_daily WHERE rn = 1) f ON m.date = f.date AND m.source_name = f.source_name
-    FULL OUTER JOIN (SELECT date, source_name, lean_body_mass_kg FROM lean_daily WHERE rn = 1) l ON coalesce(m.date, f.date) = l.date AND coalesce(m.source_name, f.source_name) = l.source_name
-    FULL OUTER JOIN (SELECT date, source_name, bmi FROM bmi_daily WHERE rn = 1) b ON coalesce(m.date, f.date, l.date) = b.date AND coalesce(m.source_name, f.source_name, l.source_name) = b.source_name
-    FULL OUTER JOIN (SELECT date, source_name, height_m FROM height_daily WHERE rn = 1) h ON coalesce(m.date, f.date, l.date, b.date) = h.date AND coalesce(m.source_name, f.source_name, l.source_name, b.source_name) = h.source_name
+    FROM (SELECT date, source_system, weight_kg FROM mass_daily WHERE rn = 1) m
+    FULL OUTER JOIN (SELECT date, source_system, body_fat_pct FROM fat_daily WHERE rn = 1) f ON m.date = f.date AND m.source_system = f.source_system
+    FULL OUTER JOIN (SELECT date, source_system, lean_body_mass_kg FROM lean_daily WHERE rn = 1) l ON coalesce(m.date, f.date) = l.date AND coalesce(m.source_system, f.source_system) = l.source_system
+    FULL OUTER JOIN (SELECT date, source_system, bmi FROM bmi_daily WHERE rn = 1) b ON coalesce(m.date, f.date, l.date) = b.date AND coalesce(m.source_system, f.source_system, l.source_system) = b.source_system
+    FULL OUTER JOIN (SELECT date, source_system, height_m FROM height_daily WHERE rn = 1) h ON coalesce(m.date, f.date, l.date, b.date) = h.date AND coalesce(m.source_system, f.source_system, l.source_system, b.source_system) = h.source_system
 )
 SELECT
     (year(date) * 10000 + month(date) * 100 + day(date))::INTEGER AS sk_date,
@@ -52,8 +52,8 @@ SELECT
     ROUND(weight_kg, 2) AS weight_kg, ROUND(body_fat_pct, 2) AS body_fat_pct,
     ROUND(lean_body_mass_kg, 2) AS lean_body_mass_kg, ROUND(bmi, 2) AS bmi, ROUND(height_m, 3) AS height_m,
     NULL::DOUBLE AS fat_mass_kg, NULL::DOUBLE AS bone_mass_kg, NULL::DOUBLE AS muscle_mass_kg, NULL::DOUBLE AS hydration_kg,
-    source_name,
-    md5(coalesce(cast(date AS VARCHAR), '') || '||' || coalesce(source_name, '')) AS business_key_hash,
+    source_system,
+    md5(coalesce(cast(date AS VARCHAR), '') || '||' || coalesce(source_system, '')) AS business_key_hash,
     md5(coalesce(cast(weight_kg AS VARCHAR), '') || '||' || coalesce(cast(body_fat_pct AS VARCHAR), '') || '||' || coalesce(cast(lean_body_mass_kg AS VARCHAR), '') || '||' || coalesce(cast(bmi AS VARCHAR), '') || '||' || coalesce(cast(height_m AS VARCHAR), '')) AS row_hash,
     current_timestamp AS load_datetime
 FROM combined;
@@ -66,14 +66,14 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
   UPDATE SET sk_date=src.sk_date, date=src.date, weight_kg=src.weight_kg, body_fat_pct=src.body_fat_pct,
     lean_body_mass_kg=src.lean_body_mass_kg, bmi=src.bmi, height_m=src.height_m,
     fat_mass_kg=src.fat_mass_kg, bone_mass_kg=src.bone_mass_kg, muscle_mass_kg=src.muscle_mass_kg, hydration_kg=src.hydration_kg,
-    source_name=src.source_name, row_hash=src.row_hash, update_datetime=current_timestamp
+    source_system=src.source_system, row_hash=src.row_hash, update_datetime=current_timestamp
 WHEN NOT MATCHED THEN
   INSERT (sk_date, date, weight_kg, body_fat_pct, lean_body_mass_kg, bmi, height_m,
     fat_mass_kg, bone_mass_kg, muscle_mass_kg, hydration_kg,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime)
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime)
   VALUES (src.sk_date, src.date, src.weight_kg, src.body_fat_pct, src.lean_body_mass_kg, src.bmi, src.height_m,
     src.fat_mass_kg, src.bone_mass_kg, src.muscle_mass_kg, src.hydration_kg,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp);
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp);
 
 -- Step 3: Drop staging table
 DROP TABLE IF EXISTS silver.body_measurement__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_body_temperature.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_body_temperature.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(startDate::TIMESTAMP)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP   AS timestamp,
     value::DOUBLE          AS temperature_degc,
-    sourceName             AS source_name,
+    sourceName             AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' ||
         coalesce(sourceName, '')
@@ -46,18 +46,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     temperature_degc  = src.temperature_degc,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, sk_time, timestamp, temperature_degc,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.sk_time, src.timestamp, src.temperature_degc,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_distance.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_distance.sql
@@ -39,7 +39,7 @@ SELECT
     startDate::TIMESTAMP AS timestamp,
     ROUND(value::DOUBLE / 1000.0, 4) AS distance_km,
     distance_type,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' ||
         coalesce(sourceName, '') || '||' ||
@@ -66,18 +66,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     timestamp         = src.timestamp,
     distance_km       = src.distance_km,
     distance_type     = src.distance_type,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, distance_km, distance_type, source_name,
+    sk_date, sk_time, timestamp, distance_km, distance_type, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.distance_km, src.distance_type, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.distance_km, src.distance_type, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_energy.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_energy.sql
@@ -1,6 +1,6 @@
 -- merge_apple_health_energy.sql
 -- Per-source merge: Apple Health -> silver.daily_energy_by_source
--- One row per date + source_name. Keeps sources separate to prevent double-counting.
+-- One row per date + source_system. Keeps sources separate to prevent double-counting.
 --
 -- Sources:
 --   bronze.stg_apple_health_active_energy_burned
@@ -13,7 +13,7 @@ CREATE OR REPLACE TABLE silver.daily_energy_by_source__staging AS
 WITH active_daily AS (
     SELECT
         startDate::DATE            AS date,
-        sourceName                 AS source_name,
+        sourceName                 AS source_system,
         SUM(value::DOUBLE)         AS active_energy_kcal,
         COUNT(*)                   AS active_sessions
     FROM bronze.stg_apple_health_active_energy_burned
@@ -24,7 +24,7 @@ WITH active_daily AS (
 basal_daily AS (
     SELECT
         startDate::DATE            AS date,
-        sourceName                 AS source_name,
+        sourceName                 AS source_system,
         SUM(value::DOUBLE)         AS basal_energy_kcal
     FROM bronze.stg_apple_health_basal_energy_burned
     WHERE startDate IS NOT NULL
@@ -34,13 +34,13 @@ basal_daily AS (
 combined AS (
     SELECT
         coalesce(a.date, b.date)               AS date,
-        coalesce(a.source_name, b.source_name) AS source_name,
+        coalesce(a.source_system, b.source_system) AS source_system,
         a.active_energy_kcal,
         a.active_sessions,
         b.basal_energy_kcal
     FROM active_daily a
     FULL OUTER JOIN basal_daily b
-        ON a.date = b.date AND a.source_name = b.source_name
+        ON a.date = b.date AND a.source_system = b.source_system
 )
 SELECT
     -- Surrogate date key
@@ -48,7 +48,7 @@ SELECT
 
     -- Business columns
     date,
-    source_name,
+    source_system,
     ROUND(active_energy_kcal, 3)                                  AS active_energy_kcal,
     ROUND(basal_energy_kcal, 3)                                   AS basal_energy_kcal,
     ROUND(coalesce(active_energy_kcal, 0)
@@ -58,7 +58,7 @@ SELECT
     -- Business key: one row per date + source
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' ||
-        coalesce(source_name, '')
+        coalesce(source_system, '')
     )                                                             AS business_key_hash,
 
     -- Row hash: change detection
@@ -81,7 +81,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
   UPDATE SET
     sk_date              = src.sk_date,
     date                 = src.date,
-    source_name          = src.source_name,
+    source_system          = src.source_system,
     active_energy_kcal   = src.active_energy_kcal,
     basal_energy_kcal    = src.basal_energy_kcal,
     total_energy_kcal    = src.total_energy_kcal,
@@ -91,13 +91,13 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, date, source_name,
+    sk_date, date, source_system,
     active_energy_kcal, basal_energy_kcal, total_energy_kcal,
     active_sessions, business_key_hash, row_hash,
     load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.date, src.source_name,
+    src.sk_date, src.date, src.source_system,
     src.active_energy_kcal, src.basal_energy_kcal, src.total_energy_kcal,
     src.active_sessions, src.business_key_hash, src.row_hash,
     current_timestamp, current_timestamp

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_exercise_time.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_exercise_time.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS exercise_minutes,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     exercise_minutes  = src.exercise_minutes,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, exercise_minutes, source_name,
+    sk_date, sk_time, timestamp, exercise_minutes, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.exercise_minutes, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.exercise_minutes, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_flights_climbed.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_flights_climbed.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS flights,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     flights           = src.flights,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, flights, source_name,
+    sk_date, sk_time, timestamp, flights, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.flights, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.flights, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hand_washing.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hand_washing.sql
@@ -22,7 +22,7 @@ SELECT
     startDate::TIMESTAMP AS timestamp,
     strptime(endDate, '%Y-%m-%d %H:%M:%S %z')::TIMESTAMP AS end_timestamp,
     duration_seconds::DOUBLE AS duration_seconds,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -48,18 +48,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     timestamp         = src.timestamp,
     end_timestamp     = src.end_timestamp,
     duration_seconds  = src.duration_seconds,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, end_timestamp, duration_seconds, source_name,
+    sk_date, sk_time, timestamp, end_timestamp, duration_seconds, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.end_timestamp, src.duration_seconds, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.end_timestamp, src.duration_seconds, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_heart_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_heart_rate.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::INTEGER AS bpm,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -43,7 +43,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     bpm               = src.bpm,
-    source_name        = src.source_name,
+    source_system        = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
@@ -54,7 +54,7 @@ WHEN NOT MATCHED THEN
     sk_time,
     timestamp,
     bpm,
-    source_name,
+    source_system,
     business_key_hash,
     row_hash,
     load_datetime,
@@ -65,7 +65,7 @@ WHEN NOT MATCHED THEN
     src.sk_time,
     src.timestamp,
     src.bpm,
-    src.source_name,
+    src.source_system,
     src.business_key_hash,
     src.row_hash,
     current_timestamp,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hr_recovery.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hr_recovery.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS recovery_bpm,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     recovery_bpm      = src.recovery_bpm,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, recovery_bpm, source_name,
+    sk_date, sk_time, timestamp, recovery_bpm, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.recovery_bpm, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.recovery_bpm, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hrv.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_hrv.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS hrv_ms,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     hrv_ms            = src.hrv_ms,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, hrv_ms, source_name,
+    sk_date, sk_time, timestamp, hrv_ms, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.hrv_ms, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.hrv_ms, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_mindful_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_mindful_session.sql
@@ -21,7 +21,7 @@ SELECT
     startDate::TIMESTAMP   AS timestamp,
     strptime(endDate, '%Y-%m-%d %H:%M:%S %z')::TIMESTAMP AS end_timestamp,
     duration_seconds,
-    sourceName             AS source_name,
+    sourceName             AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' ||
         coalesce(sourceName, '')
@@ -48,19 +48,19 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     timestamp         = src.timestamp,
     end_timestamp     = src.end_timestamp,
     duration_seconds  = src.duration_seconds,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, sk_time, timestamp, end_timestamp,
-    duration_seconds, source_name,
+    duration_seconds, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.sk_time, src.timestamp, src.end_timestamp,
-    src.duration_seconds, src.source_name,
+    src.duration_seconds, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_physical_effort.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_physical_effort.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS effort_kj_per_hr_kg,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time              = src.sk_time,
     timestamp            = src.timestamp,
     effort_kj_per_hr_kg  = src.effort_kj_per_hr_kg,
-    source_name          = src.source_name,
+    source_system          = src.source_system,
     business_key_hash    = src.business_key_hash,
     row_hash             = src.row_hash,
     update_datetime      = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, effort_kj_per_hr_kg, source_name,
+    sk_date, sk_time, timestamp, effort_kj_per_hr_kg, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.effort_kj_per_hr_kg, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.effort_kj_per_hr_kg, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_respiratory_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_respiratory_rate.sql
@@ -22,7 +22,7 @@ SELECT
     startDate::TIMESTAMP   AS timestamp,
     strptime(endDate, '%Y-%m-%d %H:%M:%S %z')::TIMESTAMP AS end_timestamp,
     value::DOUBLE          AS breaths_per_min,
-    sourceName             AS source_name,
+    sourceName             AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' ||
         coalesce(sourceName, '')
@@ -48,19 +48,19 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     timestamp       = src.timestamp,
     end_timestamp   = src.end_timestamp,
     breaths_per_min = src.breaths_per_min,
-    source_name     = src.source_name,
+    source_system     = src.source_system,
     row_hash        = src.row_hash,
     update_datetime = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, sk_time, timestamp, end_timestamp,
-    breaths_per_min, source_name,
+    breaths_per_min, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.sk_time, src.timestamp, src.end_timestamp,
-    src.breaths_per_min, src.source_name,
+    src.breaths_per_min, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_resting_heart_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_resting_heart_rate.sql
@@ -1,7 +1,7 @@
 -- merge_apple_health_resting_heart_rate.sql
 -- Per-source merge: Apple Health -> silver.resting_heart_rate
 -- Daily resting heart rate, one row per date
--- Shared table: source_name in BK for future Oura data (A6)
+-- Shared table: source_system in BK for future Oura data (A6)
 --
 -- Usage: python run_merge.py silver/merge_apple_health_resting_heart_rate.sql
 
@@ -22,7 +22,7 @@ SELECT
     (year(startDate) * 10000 + month(startDate) * 100 + day(startDate))::INTEGER AS sk_date,
     startDate::DATE AS date,
     value::DOUBLE AS resting_hr_bpm,
-    'apple_health' AS source_name,
+    'apple_health' AS source_system,
     md5(
         coalesce(cast(startDate::DATE AS VARCHAR), '') || '||' || 'apple_health'
     ) AS business_key_hash,
@@ -44,17 +44,17 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_date           = src.sk_date,
     date              = src.date,
     resting_hr_bpm    = src.resting_hr_bpm,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, date, resting_hr_bpm, source_name,
+    sk_date, date, resting_hr_bpm, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.date, src.resting_hr_bpm, src.source_name,
+    src.sk_date, src.date, src.resting_hr_bpm, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_running_speed.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_running_speed.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS speed_m_per_s,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     speed_m_per_s     = src.speed_m_per_s,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, speed_m_per_s, source_name,
+    sk_date, sk_time, timestamp, speed_m_per_s, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.speed_m_per_s, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.speed_m_per_s, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_six_min_walk.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_six_min_walk.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate)::VARCHAR, 2, '0') || lpad(minute(startDate)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP AS timestamp,
     value::DOUBLE AS distance_m,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -45,18 +45,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time           = src.sk_time,
     timestamp         = src.timestamp,
     distance_m        = src.distance_m,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, sk_time, timestamp, distance_m, source_name,
+    sk_date, sk_time, timestamp, distance_m, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.distance_m, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.distance_m, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_stand_time.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_stand_time.sql
@@ -40,7 +40,7 @@ SELECT
     date,
     ROUND(stand_minutes, 1) AS stand_minutes,
     coalesce(stand_hours, 0) AS stand_hours,
-    'apple_health' AS source_name,
+    'apple_health' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' || 'apple_health'
     ) AS business_key_hash,
@@ -62,17 +62,17 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     date              = src.date,
     stand_minutes     = src.stand_minutes,
     stand_hours       = src.stand_hours,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, date, stand_minutes, stand_hours, source_name,
+    sk_date, date, stand_minutes, stand_hours, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.date, src.stand_minutes, src.stand_hours, src.source_name,
+    src.sk_date, src.date, src.stand_minutes, src.stand_hours, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_step_count.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_step_count.sql
@@ -23,7 +23,7 @@ SELECT
     strptime(endDate, '%Y-%m-%d %H:%M:%S %z')::TIMESTAMP AS end_timestamp,
     duration_seconds,
     value::INTEGER AS step_count,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -51,7 +51,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     end_timestamp     = src.end_timestamp,
     duration_seconds  = src.duration_seconds,
     step_count        = src.step_count,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
@@ -64,7 +64,7 @@ WHEN NOT MATCHED THEN
     end_timestamp,
     duration_seconds,
     step_count,
-    source_name,
+    source_system,
     business_key_hash,
     row_hash,
     load_datetime,
@@ -77,7 +77,7 @@ WHEN NOT MATCHED THEN
     src.end_timestamp,
     src.duration_seconds,
     src.step_count,
-    src.source_name,
+    src.source_system,
     src.business_key_hash,
     src.row_hash,
     current_timestamp,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_toothbrushing.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_toothbrushing.sql
@@ -22,7 +22,7 @@ SELECT
     startDate::TIMESTAMP AS timestamp,
     strptime(endDate, '%Y-%m-%d %H:%M:%S %z')::TIMESTAMP AS end_timestamp,
     duration_seconds,
-    sourceName AS source_name,
+    sourceName AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' || coalesce(sourceName, '')
     ) AS business_key_hash,
@@ -48,7 +48,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     timestamp         = src.timestamp,
     end_timestamp     = src.end_timestamp,
     duration_seconds  = src.duration_seconds,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     business_key_hash = src.business_key_hash,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
@@ -60,7 +60,7 @@ WHEN NOT MATCHED THEN
     timestamp,
     end_timestamp,
     duration_seconds,
-    source_name,
+    source_system,
     business_key_hash,
     row_hash,
     load_datetime,
@@ -72,7 +72,7 @@ WHEN NOT MATCHED THEN
     src.timestamp,
     src.end_timestamp,
     src.duration_seconds,
-    src.source_name,
+    src.source_system,
     src.business_key_hash,
     src.row_hash,
     current_timestamp,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_vo2_max.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_vo2_max.sql
@@ -1,7 +1,7 @@
 -- merge_apple_health_vo2_max.sql
 -- Per-source merge: Apple Health -> silver.vo2_max
 -- VO2 Max cardio fitness estimate, daily grain
--- Shared table: source_name in BK for future Oura data (A6)
+-- Shared table: source_system in BK for future Oura data (A6)
 --
 -- Usage: python run_merge.py silver/merge_apple_health_vo2_max.sql
 
@@ -22,7 +22,7 @@ SELECT
     (year(startDate) * 10000 + month(startDate) * 100 + day(startDate))::INTEGER AS sk_date,
     startDate::DATE AS date,
     value::DOUBLE AS vo2_max_ml_kg_min,
-    'apple_health' AS source_name,
+    'apple_health' AS source_system,
     md5(
         coalesce(cast(startDate::DATE AS VARCHAR), '') || '||' || 'apple_health'
     ) AS business_key_hash,
@@ -44,17 +44,17 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_date              = src.sk_date,
     date                 = src.date,
     vo2_max_ml_kg_min    = src.vo2_max_ml_kg_min,
-    source_name          = src.source_name,
+    source_system          = src.source_system,
     row_hash             = src.row_hash,
     update_datetime      = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
-    sk_date, date, vo2_max_ml_kg_min, source_name,
+    sk_date, date, vo2_max_ml_kg_min, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
-    src.sk_date, src.date, src.vo2_max_ml_kg_min, src.source_name,
+    src.sk_date, src.date, src.vo2_max_ml_kg_min, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_water.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_apple_health_water.sql
@@ -21,7 +21,7 @@ SELECT
     lpad(hour(startDate::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(startDate::TIMESTAMP)::VARCHAR, 2, '0') AS sk_time,
     startDate::TIMESTAMP   AS timestamp,
     value::DOUBLE          AS water_ml,
-    sourceName             AS source_name,
+    sourceName             AS source_system,
     md5(
         coalesce(cast(startDate AS VARCHAR), '') || '||' ||
         coalesce(sourceName, '')
@@ -46,18 +46,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_time         = src.sk_time,
     timestamp       = src.timestamp,
     water_ml        = src.water_ml,
-    source_name     = src.source_name,
+    source_system     = src.source_system,
     row_hash        = src.row_hash,
     update_datetime = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, sk_time, timestamp, water_ml,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.sk_time, src.timestamp, src.water_ml,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_csv_skin_temperature.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_csv_skin_temperature.sql
@@ -24,7 +24,7 @@ SELECT
     min_skin_temp,
     max_skin_temp,
     sample_count,
-    'oura' AS source_name,
+    'oura' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' || 'oura'
     ) AS business_key_hash,
@@ -51,18 +51,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     min_skin_temp     = src.min_skin_temp,
     max_skin_temp     = src.max_skin_temp,
     sample_count      = src.sample_count,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, date, avg_skin_temp, min_skin_temp, max_skin_temp, sample_count,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.date, src.avg_skin_temp, src.min_skin_temp, src.max_skin_temp, src.sample_count,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_daily_activity.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_daily_activity.sql
@@ -47,6 +47,7 @@ SELECT
     contributors.stay_active::INTEGER                 AS contributor_stay_active,
     contributors.training_frequency::INTEGER          AS contributor_training_frequency,
     contributors.training_volume::INTEGER             AS contributor_training_volume,
+    'oura'                                            AS source_system,
     md5(full_date::VARCHAR)                           AS business_key_hash,
     md5(
         coalesce(cast(score AS VARCHAR), '')                              || '||' ||
@@ -97,6 +98,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN UPDATE SET
     contributor_stay_active        = src.contributor_stay_active,
     contributor_training_frequency = src.contributor_training_frequency,
     contributor_training_volume    = src.contributor_training_volume,
+    source_system                  = src.source_system,
     row_hash                       = src.row_hash,
     update_datetime                = current_timestamp
 
@@ -111,7 +113,7 @@ WHEN NOT MATCHED THEN INSERT (
     contributor_meet_daily_targets, contributor_move_every_hour,
     contributor_recovery_time, contributor_stay_active,
     contributor_training_frequency, contributor_training_volume,
-    business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
 ) VALUES (
     src.sk_date, src.day, src.activity_score, src.timestamp, src.steps, src.total_calories, src.active_calories,
     src.target_calories, src.average_met_minutes, src.equivalent_walking_distance,
@@ -123,7 +125,7 @@ WHEN NOT MATCHED THEN INSERT (
     src.contributor_meet_daily_targets, src.contributor_move_every_hour,
     src.contributor_recovery_time, src.contributor_stay_active,
     src.contributor_training_frequency, src.contributor_training_volume,
-    src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
 );
 
 DROP TABLE IF EXISTS silver.daily_activity__staging;

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_heartrate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_heartrate.sql
@@ -1,6 +1,6 @@
 -- merge_oura_heartrate.sql
 -- Per-source merge: Oura API -> silver.heart_rate
--- Business key: timestamp + source_name (per-minute readings)
+-- Business key: timestamp + source_system (per-minute readings)
 --
 -- Usage: python run_merge.py silver/merge_oura_heartrate.sql
 
@@ -16,7 +16,7 @@ SELECT
     lpad(hour(timestamp::TIMESTAMP)::VARCHAR, 2, '0') || lpad(minute(timestamp::TIMESTAMP)::VARCHAR, 2, '0')       AS sk_time,
     timestamp::TIMESTAMP              AS timestamp,
     bpm::INTEGER                      AS bpm,
-    source                            AS source_name,
+    source                            AS source_system,
     md5(
         coalesce(timestamp, '') || '||' || coalesce(source, '')
     )                                 AS business_key_hash,
@@ -37,15 +37,15 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN UPDATE SET
     sk_time         = src.sk_time,
     timestamp       = src.timestamp,
     bpm             = src.bpm,
-    source_name     = src.source_name,
+    source_system     = src.source_system,
     row_hash        = src.row_hash,
     update_datetime = current_timestamp
 
 WHEN NOT MATCHED THEN INSERT (
-    sk_date, sk_time, timestamp, bpm, source_name,
+    sk_date, sk_time, timestamp, bpm, source_system,
     business_key_hash, row_hash, load_datetime, update_datetime
 ) VALUES (
-    src.sk_date, src.sk_time, src.timestamp, src.bpm, src.source_name,
+    src.sk_date, src.sk_time, src.timestamp, src.bpm, src.source_system,
     src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
 );
 

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_sleep_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_oura_sleep_session.sql
@@ -1,6 +1,6 @@
 -- merge_oura_sleep_session.sql
 -- Per-source merge: Oura (API + CSV) -> silver.sleep_session
--- Shared table: source_name distinguishes Oura from Withings sleep data.
+-- Shared table: source_system distinguishes Oura from Withings sleep data.
 -- Handles both API rows (Hive year/month/day partitions) and CSV rows (day as full date).
 -- Normalizes sleep metrics to minutes for cross-source comparison.
 -- Filters out 'rest' type entries (naps without full sleep metrics).
@@ -56,7 +56,7 @@ SELECT
     ) AS readiness_score,
     NULL::DOUBLE AS snoring_min,
     NULL::INTEGER AS snoring_episodes,
-    'oura' AS source_name,
+    'oura' AS source_system,
     md5(
         coalesce(cast(full_date AS VARCHAR), '') || '||' ||
         coalesce(cast(bedtime_start AS VARCHAR), '') || '||' || 'oura'
@@ -100,7 +100,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     readiness_score   = src.readiness_score,
     snoring_min       = src.snoring_min,
     snoring_episodes  = src.snoring_episodes,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
@@ -109,13 +109,13 @@ WHEN NOT MATCHED THEN
     sk_date, date, bedtime_start, bedtime_end, total_sleep_min, deep_sleep_min, rem_sleep_min,
     light_sleep_min, awake_min, efficiency, latency_min, avg_hr, min_hr, max_hr, avg_hrv,
     lowest_hr, readiness_score, snoring_min, snoring_episodes,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.date, src.bedtime_start, src.bedtime_end, src.total_sleep_min, src.deep_sleep_min, src.rem_sleep_min,
     src.light_sleep_min, src.awake_min, src.efficiency, src.latency_min, src.avg_hr, src.min_hr, src.max_hr, src.avg_hrv,
     src.lowest_hr, src.readiness_score, src.snoring_min, src.snoring_episodes,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_activity.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_activity.sql
@@ -32,7 +32,7 @@ SELECT
     TRY_CAST(hr_zone_1 AS INTEGER) AS hr_zone_1_s,
     TRY_CAST(hr_zone_2 AS INTEGER) AS hr_zone_2_s,
     TRY_CAST(hr_zone_3 AS INTEGER) AS hr_zone_3_s,
-    'withings' AS source_name,
+    'withings' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -71,7 +71,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     hr_zone_1_s                  = src.hr_zone_1_s,
     hr_zone_2_s                  = src.hr_zone_2_s,
     hr_zone_3_s                  = src.hr_zone_3_s,
-    source_name                  = src.source_name,
+    source_system                  = src.source_system,
     row_hash                     = src.row_hash,
     update_datetime              = current_timestamp
 
@@ -80,13 +80,13 @@ WHEN NOT MATCHED THEN
     sk_date, date, steps, distance_m, elevation_m, calories, active_calories, total_calories,
     soft_activity_duration_s, moderate_activity_duration_s, intense_activity_duration_s,
     hr_average, hr_min, hr_max, hr_zone_0_s, hr_zone_1_s, hr_zone_2_s, hr_zone_3_s,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.date, src.steps, src.distance_m, src.elevation_m, src.calories, src.active_calories, src.total_calories,
     src.soft_activity_duration_s, src.moderate_activity_duration_s, src.intense_activity_duration_s,
     src.hr_average, src.hr_min, src.hr_max, src.hr_zone_0_s, src.hr_zone_1_s, src.hr_zone_2_s, src.hr_zone_3_s,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_body_temperature.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_body_temperature.sql
@@ -30,7 +30,7 @@ combined AS (
     SELECT
         datetime::TIMESTAMP AS timestamp,
         ROUND(temperature_c::DOUBLE, 1) AS temperature_degc,
-        'withings' AS source_name
+        'withings' AS source_system
     FROM api_source WHERE rn = 1
 
     UNION ALL
@@ -39,7 +39,7 @@ combined AS (
     SELECT
         date::TIMESTAMP AS timestamp,
         ROUND(TRY_CAST("value (°C)" AS DOUBLE), 1) AS temperature_degc,
-        'withings' AS source_name
+        'withings' AS source_system
     FROM csv_source_legacy WHERE rn = 1
 
     UNION ALL
@@ -48,12 +48,12 @@ combined AS (
     SELECT
         date::TIMESTAMP AS timestamp,
         ROUND(TRY_CAST("value (°C)" AS DOUBLE), 1) AS temperature_degc,
-        'withings' AS source_name
+        'withings' AS source_system
     FROM csv_source_new WHERE rn = 1
 ),
 final_dedup AS (
     SELECT *,
-        ROW_NUMBER() OVER (PARTITION BY timestamp ORDER BY source_name ASC, temperature_degc DESC NULLS LAST) AS rn
+        ROW_NUMBER() OVER (PARTITION BY timestamp ORDER BY source_system ASC, temperature_degc DESC NULLS LAST) AS rn
     FROM combined
     WHERE timestamp IS NOT NULL
 )
@@ -61,7 +61,7 @@ SELECT
     (year(timestamp::DATE) * 10000 + month(timestamp::DATE) * 100 + day(timestamp::DATE))::INTEGER AS sk_date,
     timestamp,
     temperature_degc,
-    source_name,
+    source_system,
     md5(
         coalesce(cast(timestamp AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -83,18 +83,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_date           = src.sk_date,
     timestamp         = src.timestamp,
     temperature_degc  = src.temperature_degc,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, timestamp, temperature_degc,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.timestamp, src.temperature_degc,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_ecg_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_ecg_session.sql
@@ -23,7 +23,7 @@ SELECT
     TRY_CAST(frequency AS INTEGER) AS frequency_hz,
     TRY_CAST(duration AS INTEGER) AS duration_s,
     wearposition,
-    'withings' AS source_name,
+    'withings' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -51,18 +51,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     frequency_hz      = src.frequency_hz,
     duration_s        = src.duration_s,
     wearposition      = src.wearposition,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, timestamp, ecg_type, frequency_hz, duration_s, wearposition,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.timestamp, src.ecg_type, src.frequency_hz, src.duration_s, src.wearposition,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_pulse_wave_velocity.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_pulse_wave_velocity.sql
@@ -20,7 +20,7 @@ SELECT
     (year(date::TIMESTAMP::DATE) * 10000 + month(date::TIMESTAMP::DATE) * 100 + day(date::TIMESTAMP::DATE))::INTEGER AS sk_date,
     date::TIMESTAMP AS timestamp,
     ROUND(TRY_CAST(value AS DOUBLE), 2) AS pwv_m_per_s,
-    'withings' AS source_name,
+    'withings' AS source_system,
     md5(
         coalesce(cast(date AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -42,18 +42,18 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     sk_date           = src.sk_date,
     timestamp         = src.timestamp,
     pwv_m_per_s       = src.pwv_m_per_s,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
 WHEN NOT MATCHED THEN
   INSERT (
     sk_date, timestamp, pwv_m_per_s,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.timestamp, src.pwv_m_per_s,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_sleep_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_sleep_session.sql
@@ -37,7 +37,7 @@ SELECT
     NULL::INTEGER AS readiness_score,
     ROUND(TRY_CAST("Snoring (s)" AS DOUBLE) / 60.0, 1) AS snoring_min,
     TRY_CAST("Snoring episodes" AS INTEGER) AS snoring_episodes,
-    'withings' AS source_name,
+    'withings' AS source_system,
     md5(
         coalesce(cast("from" AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -80,7 +80,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     readiness_score   = src.readiness_score,
     snoring_min       = src.snoring_min,
     snoring_episodes  = src.snoring_episodes,
-    source_name       = src.source_name,
+    source_system       = src.source_system,
     row_hash          = src.row_hash,
     update_datetime   = current_timestamp
 
@@ -89,13 +89,13 @@ WHEN NOT MATCHED THEN
     sk_date, date, bedtime_start, bedtime_end, total_sleep_min, deep_sleep_min, rem_sleep_min,
     light_sleep_min, awake_min, efficiency, latency_min, avg_hr, min_hr, max_hr, avg_hrv,
     lowest_hr, readiness_score, snoring_min, snoring_episodes,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.date, src.bedtime_start, src.bedtime_end, src.total_sleep_min, src.deep_sleep_min, src.rem_sleep_min,
     src.light_sleep_min, src.awake_min, src.efficiency, src.latency_min, src.avg_hr, src.min_hr, src.max_hr, src.avg_hrv,
     src.lowest_hr, src.readiness_score, src.snoring_min, src.snoring_episodes,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_workouts.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/merge/silver/merge_withings_workouts.sql
@@ -43,7 +43,7 @@ SELECT
     TRY_CAST(hr_zone_3 AS INTEGER) AS hr_zone_3_s,
     TRY_CAST(pause_duration AS INTEGER) AS pause_duration_s,
     ROUND(TRY_CAST(spo2_average AS DOUBLE), 1) AS spo2_average,
-    'withings' AS source_name,
+    'withings' AS source_system,
     md5(
         coalesce(cast(id AS VARCHAR), '') || '||' || 'withings'
     ) AS business_key_hash,
@@ -82,7 +82,7 @@ WHEN MATCHED AND target.row_hash <> src.row_hash THEN
     hr_zone_3_s      = src.hr_zone_3_s,
     pause_duration_s = src.pause_duration_s,
     spo2_average     = src.spo2_average,
-    source_name      = src.source_name,
+    source_system      = src.source_system,
     row_hash         = src.row_hash,
     update_datetime  = current_timestamp
 
@@ -91,13 +91,13 @@ WHEN NOT MATCHED THEN
     sk_date, start_datetime, end_datetime, category, calories, steps, distance_m, elevation_m,
     intensity, hr_average, hr_min, hr_max, hr_zone_0_s, hr_zone_1_s, hr_zone_2_s, hr_zone_3_s,
     pause_duration_s, spo2_average,
-    source_name, business_key_hash, row_hash, load_datetime, update_datetime
+    source_system, business_key_hash, row_hash, load_datetime, update_datetime
   )
   VALUES (
     src.sk_date, src.start_datetime, src.end_datetime, src.category, src.calories, src.steps, src.distance_m, src.elevation_m,
     src.intensity, src.hr_average, src.hr_min, src.hr_max, src.hr_zone_0_s, src.hr_zone_1_s, src.hr_zone_2_s, src.hr_zone_3_s,
     src.pause_duration_s, src.spo2_average,
-    src.source_name, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
+    src.source_system, src.business_key_hash, src.row_hash, current_timestamp, current_timestamp
   );
 
 -- Step 3: Drop staging table

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/audio_exposure.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/audio_exposure.sql
@@ -15,7 +15,7 @@ select
     null::double     as avg_db,
     null::double     as max_db,
     null::integer    as sample_count,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_pressure_v2.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/blood_pressure_v2.sql
@@ -16,7 +16,7 @@ select
     null::double     as systolic_mmhg,
     null::double     as diastolic_mmhg,
     null::double     as pulse_bpm,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/body_measurement.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/body_measurement.sql
@@ -20,7 +20,7 @@ select
     null::double     as bone_mass_kg,
     null::double     as muscle_mass_kg,
     null::double     as hydration_kg,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/body_temperature.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/body_temperature.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as temperature_degc,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/cardiovascular_age.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/cardiovascular_age.sql
@@ -12,7 +12,7 @@ select
     null::integer    as sk_date,
     null::date       as date,
     null::integer    as vascular_age,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_activity.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_activity.sql
@@ -36,6 +36,7 @@ select
     null::integer    as contributor_stay_active,
     null::integer    as contributor_training_frequency,
     null::integer    as contributor_training_volume,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_energy_by_source.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_energy_by_source.sql
@@ -11,7 +11,7 @@
 select
     null::integer    as sk_date,
     null::date       as date,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::double     as active_energy_kcal,
     null::double     as basal_energy_kcal,
     null::double     as total_energy_kcal,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_resilience.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daily_resilience.sql
@@ -15,7 +15,7 @@ select
     null::double     as daytime_recovery,
     null::double     as stress,
     null::varchar    as level,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daytime_stress.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/daytime_stress.sql
@@ -16,7 +16,7 @@ select
     null::double     as avg_recovery,
     null::double     as max_recovery,
     null::integer    as sample_count,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/distance.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/distance.sql
@@ -14,7 +14,7 @@ select
     null::timestamp  as timestamp,
     null::double     as distance_km,
     null::varchar    as distance_type,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/ecg_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/ecg_session.sql
@@ -15,7 +15,7 @@ select
     null::integer    as frequency_hz,
     null::integer    as duration_s,
     null::varchar    as wearposition,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/enhanced_tag.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/enhanced_tag.sql
@@ -17,7 +17,7 @@ select
     null::varchar    as tag_type_code,
     null::varchar    as custom_tag_name,
     null::varchar    as comment,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/exercise_time.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/exercise_time.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as exercise_minutes,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/flights_climbed.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/flights_climbed.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as flights,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hand_washing.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hand_washing.sql
@@ -14,7 +14,7 @@ select
     null::timestamp  as timestamp,
     null::timestamp  as end_timestamp,
     null::double     as duration_seconds,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/heart_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/heart_rate.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::integer    as bpm,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hr_recovery.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hr_recovery.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as recovery_bpm,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hrv.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/hrv.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as hrv_ms,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/mindful_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/mindful_session.sql
@@ -14,7 +14,7 @@ select
     null::timestamp  as timestamp,
     null::timestamp  as end_timestamp,
     null::double     as duration_seconds,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/physical_effort.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/physical_effort.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as effort_kj_per_hr_kg,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/pulse_wave_velocity.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/pulse_wave_velocity.sql
@@ -12,7 +12,7 @@ select
     null::integer    as sk_date,
     null::timestamp  as timestamp,
     null::double     as pwv_m_per_s,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/respiratory_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/respiratory_rate.sql
@@ -14,7 +14,7 @@ select
     null::timestamp  as timestamp,
     null::timestamp  as end_timestamp,
     null::double     as breaths_per_min,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/resting_heart_rate.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/resting_heart_rate.sql
@@ -12,7 +12,7 @@ select
     null::integer    as sk_date,
     null::date       as date,
     null::double     as resting_hr_bpm,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/running_speed.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/running_speed.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as speed_m_per_s,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/six_min_walk.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/six_min_walk.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as distance_m,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/skin_temperature.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/skin_temperature.sql
@@ -15,7 +15,7 @@ select
     null::double     as min_skin_temp,
     null::double     as max_skin_temp,
     null::integer    as sample_count,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/sleep_recommendation.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/sleep_recommendation.sql
@@ -15,7 +15,7 @@ select
     null::varchar    as status,
     null::integer    as optimal_start_offset,
     null::integer    as optimal_end_offset,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/sleep_session.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/sleep_session.sql
@@ -28,7 +28,7 @@ select
     null::integer    as readiness_score,
     null::double     as snoring_min,
     null::integer    as snoring_episodes,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/stand_time.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/stand_time.sql
@@ -13,7 +13,7 @@ select
     null::date       as date,
     null::double     as stand_minutes,
     null::integer    as stand_hours,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/step_count.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/step_count.sql
@@ -15,7 +15,7 @@ select
     null::timestamp  as end_timestamp,
     null::double     as duration_seconds,
     null::integer    as step_count,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/toothbrushing.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/toothbrushing.sql
@@ -14,7 +14,7 @@ select
     null::timestamp  as timestamp,
     null::timestamp  as end_timestamp,
     null::double     as duration_seconds,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/vo2_max.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/vo2_max.sql
@@ -12,7 +12,7 @@ select
     null::integer    as sk_date,
     null::date       as date,
     null::double     as vo2_max_ml_kg_min,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/water_intake.sql
+++ b/health_unified_platform/health_platform/transformation_logic/dbt/models/silver/water_intake.sql
@@ -13,7 +13,7 @@ select
     null::varchar    as sk_time,
     null::timestamp  as timestamp,
     null::double     as water_ml,
-    null::varchar    as source_name,
+    null::varchar    as source_system,
     null::varchar    as business_key_hash,
     null::varchar    as row_hash,
     null::timestamp  as load_datetime,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,7 +344,7 @@ def seeded_db(memory_db):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -352,7 +352,7 @@ def seeded_db(memory_db):
     )
     con.execute(
         """
-        INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name)
+        INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system)
         VALUES
             (20260301, '2026-03-01 03:00:00', 52, 'Oura Ring'),
             (20260301, '2026-03-01 12:00:00', 78, 'Apple Watch'),

--- a/tests/test_base_connector.py
+++ b/tests/test_base_connector.py
@@ -22,7 +22,7 @@ class TestBaseConnectorABC:
 
         class IncompleteConnector(BaseConnector):
             @property
-            def source_name(self) -> str:
+            def source_system(self) -> str:
                 return "incomplete"
 
             def authenticate(self) -> None:
@@ -48,8 +48,8 @@ class TestOuraClientImplementsBaseConnector:
     def test_isinstance_check(self, client):
         assert isinstance(client, BaseConnector)
 
-    def test_source_name_returns_oura(self, client):
-        assert client.source_name == "oura"
+    def test_source_system_returns_oura(self, client):
+        assert client.source_system == "oura"
 
     def test_get_endpoints_returns_expected(self, client):
         endpoints = client.get_endpoints()

--- a/tests/test_bronze_validation.py
+++ b/tests/test_bronze_validation.py
@@ -57,7 +57,7 @@ def bronze_db():
             unit VARCHAR,
             start_date TIMESTAMP,
             end_date TIMESTAMP,
-            source_name VARCHAR,
+            source_system VARCHAR,
             device VARCHAR,
             load_datetime TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             source_file VARCHAR
@@ -168,7 +168,7 @@ class TestNullRateCalculations:
                     * 100.0 / COUNT(*), 1
                 ) AS value_null_pct,
                 ROUND(
-                    SUM(CASE WHEN source_name IS NULL THEN 1 ELSE 0 END)
+                    SUM(CASE WHEN source_system IS NULL THEN 1 ELSE 0 END)
                     * 100.0 / COUNT(*), 1
                 ) AS source_null_pct
             FROM bronze.stg_apple_health_heart_rate

--- a/tests/test_data_lake_integration.py
+++ b/tests/test_data_lake_integration.py
@@ -130,7 +130,7 @@ class TestSourcesConfigAlignment:
     """sources_config.yaml relative_paths must match data on disk."""
 
     @pytest.mark.parametrize(
-        "source_name,relative_path",
+        "source_system,relative_path",
         [
             ("strava_activities", "strava/raw/activities/**/*.parquet"),
             ("strava_athlete_stats", "strava/raw/athlete_stats/**/*.parquet"),
@@ -145,16 +145,16 @@ class TestSourcesConfigAlignment:
         ],
     )
     def test_config_entry_matches_disk(
-        self, sources_config, source_name: str, relative_path: str
+        self, sources_config, source_system: str, relative_path: str
     ):
         """Verify each config entry exists and its glob resolves to files."""
         # Find entry in config
-        entry = next((s for s in sources_config if s["name"] == source_name), None)
+        entry = next((s for s in sources_config if s["name"] == source_system), None)
         assert (
             entry is not None
-        ), f"Source '{source_name}' missing from sources_config.yaml"
+        ), f"Source '{source_system}' missing from sources_config.yaml"
         assert entry["relative_path"] == relative_path, (
-            f"Path mismatch for {source_name}: "
+            f"Path mismatch for {source_system}: "
             f"config={entry['relative_path']}, expected={relative_path}"
         )
 
@@ -165,7 +165,7 @@ class TestSourcesConfigAlignment:
             pytest.skip(f"{full_path} not yet populated")
         files = list(full_path.rglob("*.parquet"))
         assert len(files) > 0, (
-            f"Config entry '{source_name}' glob resolves to 0 files at "
+            f"Config entry '{source_system}' glob resolves to 0 files at "
             f"{CANONICAL_ROOT / relative_path}"
         )
 

--- a/tests/test_desktop_api.py
+++ b/tests/test_desktop_api.py
@@ -116,7 +116,7 @@ def dev_db(tmp_path):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -124,7 +124,7 @@ def dev_db(tmp_path):
     )
     con.execute(
         """
-        INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name)
+        INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system)
         VALUES
             (20260301, '2026-03-01 03:00:00', 52, 'Oura Ring'),
             (20260301, '2026-03-01 12:00:00', 78, 'Apple Watch'),

--- a/tests/test_desktop_api_reports.py
+++ b/tests/test_desktop_api_reports.py
@@ -123,7 +123,7 @@ def report_db(tmp_path):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -132,7 +132,7 @@ def report_db(tmp_path):
     for d in days:
         sk = int(d.strftime("%Y%m%d"))
         con.execute(
-            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name) VALUES (?, ?, ?, ?)",
+            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system) VALUES (?, ?, ?, ?)",
             [sk, f"{d} 03:00:00", random.randint(48, 62), "Oura Ring"],
         )
 

--- a/tests/test_desktop_chat_cli.py
+++ b/tests/test_desktop_chat_cli.py
@@ -108,7 +108,7 @@ def chat_db(tmp_path):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -117,7 +117,7 @@ def chat_db(tmp_path):
     for d in days:
         sk = int(d.strftime("%Y%m%d"))
         con.execute(
-            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name) VALUES (?, ?, ?, ?)",
+            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system) VALUES (?, ?, ?, ?)",
             [sk, f"{d} 03:00:00", random.randint(48, 60), "Oura Ring"],
         )
 

--- a/tests/test_desktop_reports.py
+++ b/tests/test_desktop_reports.py
@@ -128,7 +128,7 @@ def report_db(tmp_path):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -138,13 +138,13 @@ def report_db(tmp_path):
         sk = int(d.strftime("%Y%m%d"))
         resting = random.randint(48, 65)
         con.execute(
-            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name) VALUES (?, ?, ?, ?)",
+            "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system) VALUES (?, ?, ?, ?)",
             [sk, f"{d} 03:00:00", resting, "Oura Ring"],
         )
         for hour in [10, 14, 18]:
             bpm = random.randint(62, 90)
             con.execute(
-                "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_name) VALUES (?, ?, ?, ?)",
+                "INSERT INTO silver.heart_rate (sk_date, timestamp, bpm, source_system) VALUES (?, ?, ?, ?)",
                 [sk, f"{d} {hour:02d}:00:00", bpm, "Apple Watch"],
             )
 

--- a/tests/test_export_fhir.py
+++ b/tests/test_export_fhir.py
@@ -202,7 +202,7 @@ def export_db(tmp_path):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )

--- a/tests/test_gold_local_views.py
+++ b/tests/test_gold_local_views.py
@@ -190,7 +190,7 @@ def gold_db():
         """
         CREATE TABLE silver.resting_heart_rate (
             sk_date INTEGER, date DATE, resting_hr_bpm INTEGER,
-            source_name VARCHAR
+            source_system VARCHAR
         )
     """
     )
@@ -242,7 +242,7 @@ def gold_db():
         """
         CREATE TABLE silver.water_intake (
             sk_date INTEGER, timestamp TIMESTAMP,
-            water_ml DOUBLE, source_name VARCHAR
+            water_ml DOUBLE, source_system VARCHAR
         )
     """
     )
@@ -322,7 +322,7 @@ def gold_db():
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
             timestamp TIMESTAMP, bpm INTEGER,
-            source_name VARCHAR
+            source_system VARCHAR
         )
     """
     )
@@ -358,7 +358,7 @@ def gold_db():
     con.execute(
         """
         CREATE TABLE silver.step_count (
-            sk_date INTEGER, source_name VARCHAR, steps INTEGER
+            sk_date INTEGER, source_system VARCHAR, steps INTEGER
         )
     """
     )
@@ -829,7 +829,7 @@ class TestLegacyViews:
         row = gold_db.execute(
             "SELECT reading_count, avg_bpm "
             "FROM gold.daily_heart_rate_summary "
-            "WHERE day = '2026-03-01' AND source_name = 'all'"
+            "WHERE day = '2026-03-01' AND source_system = 'all'"
         ).fetchone()
         assert row[0] == 3  # 3 readings on day 1
         assert row[1] is not None

--- a/tests/test_intelligence_b4_c2.py
+++ b/tests/test_intelligence_b4_c2.py
@@ -174,7 +174,7 @@ def extended_db(memory_db):
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -167,7 +167,7 @@ def smoke_db():
         """
         CREATE TABLE silver.heart_rate (
             sk_date INTEGER, sk_time VARCHAR,
-            timestamp TIMESTAMP, bpm INTEGER, source_name VARCHAR,
+            timestamp TIMESTAMP, bpm INTEGER, source_system VARCHAR,
             business_key_hash VARCHAR, row_hash VARCHAR,
             load_datetime TIMESTAMP, update_datetime TIMESTAMP
         )
@@ -175,7 +175,7 @@ def smoke_db():
     )
     con.execute(
         """
-        INSERT INTO silver.heart_rate (timestamp, bpm, source_name) VALUES
+        INSERT INTO silver.heart_rate (timestamp, bpm, source_system) VALUES
         ('2026-02-20 03:00:00', 52, 'Oura Ring'),
         ('2026-02-20 12:00:00', 78, 'Apple Watch'),
         ('2026-02-21 03:00:00', 55, 'Oura Ring')

--- a/tests/test_new_functionality.py
+++ b/tests/test_new_functionality.py
@@ -580,7 +580,7 @@ class TestValidationResult:
         assert vr.fail_count == 1
         assert vr.total == 3
 
-    def test_summary_contains_source_name(self):
+    def test_summary_contains_source_system(self):
         vr = ValidationResult("Blood Panel")
         vr.add("count", "PASS", "10", "10")
         summary = vr.summary()

--- a/tests/test_silver_apple_health.py
+++ b/tests/test_silver_apple_health.py
@@ -5,7 +5,7 @@ Validates all 15 new silver tables created in A3:
 - No null business_key_hash
 - No duplicate business_key_hash
 - sk_date within valid range (20100101-20261231)
-- source_name populated (shared tables only)
+- source_system populated (shared tables only)
 """
 
 from __future__ import annotations
@@ -110,14 +110,14 @@ class TestSkDateRange:
 
 
 class TestSourceNamePopulated:
-    """Verify source_name is populated in all tables."""
+    """Verify source_system is populated in all tables."""
 
     @pytest.mark.parametrize("table", ALL_TABLES)
-    def test_source_name_not_null(self, db, table):
+    def test_source_system_not_null(self, db, table):
         null_count = db.execute(
-            f"SELECT COUNT(*) FROM silver.{table} WHERE source_name IS NULL"
+            f"SELECT COUNT(*) FROM silver.{table} WHERE source_system IS NULL"
         ).fetchone()[0]
-        assert null_count == 0, f"silver.{table} has {null_count} null source_name"
+        assert null_count == 0, f"silver.{table} has {null_count} null source_system"
 
 
 class TestSimpleEventColumns:
@@ -189,7 +189,7 @@ class TestBodyMeasurement:
 
     def test_has_multiple_sources(self, db):
         sources = db.execute(
-            "SELECT COUNT(DISTINCT source_name) FROM silver.body_measurement"
+            "SELECT COUNT(DISTINCT source_system) FROM silver.body_measurement"
         ).fetchone()[0]
         assert sources >= 2, f"Expected multiple sources, got {sources}"
 

--- a/tests/test_silver_oura_csv.py
+++ b/tests/test_silver_oura_csv.py
@@ -5,7 +5,7 @@ Validates 6 new silver tables created from Oura CSV exports:
 - No null business_key_hash
 - No duplicate business_key_hash
 - sk_date within valid range (20100101-20261231)
-- source_name is 'oura'
+- source_system is 'oura'
 - Domain-specific validations (age range, temp range, sample counts)
 """
 
@@ -83,16 +83,16 @@ class TestOuraCsvSkDateRange:
 
 
 class TestOuraCsvSourceName:
-    """Verify source_name is 'oura' for all Oura CSV tables."""
+    """Verify source_system is 'oura' for all Oura CSV tables."""
 
     @pytest.mark.parametrize("table", OURA_CSV_TABLES)
     def test_source_is_oura(self, db, table):
         non_oura = db.execute(
-            f"SELECT COUNT(*) FROM silver.{table} WHERE source_name != 'oura'"
+            f"SELECT COUNT(*) FROM silver.{table} WHERE source_system != 'oura'"
         ).fetchone()[0]
         assert (
             non_oura == 0
-        ), f"silver.{table} has {non_oura} rows with source_name != 'oura'"
+        ), f"silver.{table} has {non_oura} rows with source_system != 'oura'"
 
 
 class TestCardiovascularAge:

--- a/tests/test_silver_shared_tables.py
+++ b/tests/test_silver_shared_tables.py
@@ -28,7 +28,7 @@ class TestSleepSession:
 
     def test_has_two_sources(self, db):
         sources = db.execute(
-            "SELECT DISTINCT source_name FROM silver.sleep_session ORDER BY 1"
+            "SELECT DISTINCT source_system FROM silver.sleep_session ORDER BY 1"
         ).fetchall()
         source_list = [s[0] for s in sources]
         assert (
@@ -75,14 +75,14 @@ class TestSleepSession:
     def test_oura_has_readiness(self, db):
         count = db.execute(
             "SELECT COUNT(*) FROM silver.sleep_session "
-            "WHERE source_name = 'oura' AND readiness_score IS NOT NULL"
+            "WHERE source_system = 'oura' AND readiness_score IS NOT NULL"
         ).fetchone()[0]
         assert count > 0, "No Oura rows with readiness_score"
 
     def test_withings_has_snoring(self, db):
         count = db.execute(
             "SELECT COUNT(*) FROM silver.sleep_session "
-            "WHERE source_name = 'withings' AND snoring_min IS NOT NULL"
+            "WHERE source_system = 'withings' AND snoring_min IS NOT NULL"
         ).fetchone()[0]
         assert count > 0, "No Withings rows with snoring_min"
 
@@ -92,7 +92,7 @@ class TestSleepSession:
             "SELECT COUNT(*) FROM ("
             "  SELECT business_key_hash FROM silver.sleep_session "
             "  GROUP BY business_key_hash "
-            "  HAVING COUNT(DISTINCT source_name) > 1"
+            "  HAVING COUNT(DISTINCT source_system) > 1"
             ")"
         ).fetchone()[0]
         assert overlap == 0, f"{overlap} business keys shared across sources"
@@ -103,7 +103,7 @@ class TestBloodPressureV2:
 
     def test_has_two_sources(self, db):
         sources = db.execute(
-            "SELECT DISTINCT source_name FROM silver.blood_pressure_v2 ORDER BY 1"
+            "SELECT DISTINCT source_system FROM silver.blood_pressure_v2 ORDER BY 1"
         ).fetchall()
         source_list = [s[0] for s in sources]
         assert len(source_list) >= 2, f"Expected 2+ sources, got {source_list}"
@@ -111,14 +111,14 @@ class TestBloodPressureV2:
     def test_withings_has_pulse(self, db):
         count = db.execute(
             "SELECT COUNT(*) FROM silver.blood_pressure_v2 "
-            "WHERE source_name = 'withings' AND pulse_bpm IS NOT NULL"
+            "WHERE source_system = 'withings' AND pulse_bpm IS NOT NULL"
         ).fetchone()[0]
         assert count > 0, "No Withings rows with pulse_bpm"
 
     def test_apple_pulse_null(self, db):
         non_null = db.execute(
             "SELECT COUNT(*) FROM silver.blood_pressure_v2 "
-            "WHERE source_name = 'apple_health' AND pulse_bpm IS NOT NULL"
+            "WHERE source_system = 'apple_health' AND pulse_bpm IS NOT NULL"
         ).fetchone()[0]
         assert (
             non_null == 0
@@ -149,14 +149,14 @@ class TestBodyMeasurement:
     def test_withings_has_fat_mass(self, db):
         count = db.execute(
             "SELECT COUNT(*) FROM silver.body_measurement "
-            "WHERE source_name = 'withings' AND fat_mass_kg IS NOT NULL"
+            "WHERE source_system = 'withings' AND fat_mass_kg IS NOT NULL"
         ).fetchone()[0]
         assert count > 0, "No Withings rows with fat_mass_kg"
 
     def test_withings_has_bone_mass(self, db):
         count = db.execute(
             "SELECT COUNT(*) FROM silver.body_measurement "
-            "WHERE source_name = 'withings' AND bone_mass_kg IS NOT NULL"
+            "WHERE source_system = 'withings' AND bone_mass_kg IS NOT NULL"
         ).fetchone()[0]
         assert count > 0, "No Withings rows with bone_mass_kg"
 

--- a/tests/test_silver_withings.py
+++ b/tests/test_silver_withings.py
@@ -111,6 +111,6 @@ class TestWithingsBodyTemperatureFeed:
 
     def test_withings_body_temp_rows(self, db):
         count = db.execute(
-            "SELECT COUNT(*) FROM silver.body_temperature WHERE source_name = 'withings'"
+            "SELECT COUNT(*) FROM silver.body_temperature WHERE source_system = 'withings'"
         ).fetchone()[0]
         assert count > 0, "No Withings rows in silver.body_temperature"


### PR DESCRIPTION
## Summary
- Renamed `source_name` → `source_system` in all 83 silver layer files
- 33 MERGE scripts, 33 model definitions, 17 tests, and `add_column_comments.sql`
- Added `source_system` column to `daily_activity` MERGE and model (was missing)
- Confirmed `weight` and `workout` already used correct column name

## Why
`source_system` is the canonical lineage column across bronze → silver → gold.
`source_name` in 32 silver tables was a convention violation — now resolved.
DQ Brain validated migration and cleared impact flag. Gate S4: RED → GREEN.

## Test plan
- [ ] Run silver MERGE scripts for Apple Health, Oura, Withings sources
- [ ] Verify `source_system` populated correctly in all silver tables
- [ ] Run DQ checks (Q1-Q5, Q7) post-merge
- [ ] Confirm no `source_name` references remain in silver layer

Generated with Claude Code